### PR TITLE
Adjust layout and navigation for responsive cleanup

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -33,14 +33,6 @@
                     </div>
                 </div>
                 
-                <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger">Resources</a>
-                    <div class="dropdown-menu">
-                        <a href="index.html#references" class="dropdown-item">References</a>
-                        <a href="#" class="dropdown-item">Documentation</a>
-                        <a href="#" class="dropdown-item">Case Studies</a>
-                    </div>
-                </div>
             </div>
             
             <div class="nav-actions">
@@ -163,15 +155,6 @@
                     <ul class="footer-links">
                         <li><a href="careers.html">Careers</a></li>
                         <li><a href="contact.html">Contact</a></li>
-                    </ul>
-                </div>
-                
-                <div class="footer-section">
-                    <h4>Resources</h4>
-                    <ul class="footer-links">
-                        <li><a href="index.html#references">References</a></li>
-                        <li><a href="#">Documentation</a></li>
-                        <li><a href="#">Case Studies</a></li>
                     </ul>
                 </div>
                 

--- a/contact.html
+++ b/contact.html
@@ -33,14 +33,6 @@
                     </div>
                 </div>
                 
-                <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger">Resources</a>
-                    <div class="dropdown-menu">
-                        <a href="index.html#references" class="dropdown-item">References</a>
-                        <a href="#" class="dropdown-item">Documentation</a>
-                        <a href="#" class="dropdown-item">Case Studies</a>
-                    </div>
-                </div>
             </div>
             
             <div class="nav-actions">
@@ -219,15 +211,6 @@
                     <ul class="footer-links">
                         <li><a href="careers.html">Careers</a></li>
                         <li><a href="contact.html">Contact</a></li>
-                    </ul>
-                </div>
-                
-                <div class="footer-section">
-                    <h4>Resources</h4>
-                    <ul class="footer-links">
-                        <li><a href="index.html#references">References</a></li>
-                        <li><a href="#">Documentation</a></li>
-                        <li><a href="#">Case Studies</a></li>
                     </ul>
                 </div>
                 

--- a/css/components.css
+++ b/css/components.css
@@ -1700,9 +1700,11 @@ img, svg, video {
 
 .footer-content {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 2rem;
     margin-bottom: 2rem;
+    align-items: start;
+    justify-items: start;
 }
 
 .footer-logo {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -99,7 +99,6 @@ body {
     background-color: var(--bg-primary);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    min-width: 1200px;
 }
 
 /* Loading Screen */
@@ -1677,15 +1676,18 @@ body {
 
 .footer-content {
     display: grid;
-    grid-template-columns: 1fr 3fr;
-    gap: 3rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 2.5rem;
+    align-items: start;
+    justify-items: start;
     margin-bottom: 2rem;
 }
 
 .footer-brand {
     display: flex;
-    align-items: center;
-    gap: 0.75rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
 }
 
 .footer-logo {
@@ -1697,12 +1699,6 @@ body {
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--primary-teal);
-}
-
-.footer-links {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 2rem;
 }
 
 .footer-section h4 {
@@ -1881,11 +1877,6 @@ body {
         gap: 2rem;
     }
     
-    .footer-links {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
-    
     .footer-bottom-content {
         flex-direction: column;
         text-align: center;
@@ -1997,7 +1988,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(135deg, var(--primary-teal) 0%, #2A9999 100%);
+    background: var(--white);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2007,7 +1998,7 @@ body {
 
 .loading-animation {
     text-align: center;
-    color: white;
+    color: var(--dark-cyan);
 }
 
 .medical-cross {

--- a/index.html
+++ b/index.html
@@ -57,14 +57,6 @@
                         </div>
                     </div>
                     
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Resources</a>
-                        <div class="dropdown-menu">
-                            <a href="#references" class="dropdown-item">References</a>
-                            <a href="#" class="dropdown-item">Documentation</a>
-                            <a href="#" class="dropdown-item">Case Studies</a>
-                        </div>
-                    </div>
                 </div>
                 
                 <div class="nav-actions">
@@ -960,33 +952,21 @@
                     <span class="footer-brand-text">CareFuse</span>
                 </div>
                 
-                <div class="footer-links">
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="#solution">Solution</a></li>
-                            <li><a href="#evidence">Evidence</a></li>
-                            <li><a href="#platform">Platform</a></li>
-                        </ul>
-                    </div>
-                    
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="#about">About</a></li>
-                            <li><a href="#careers">Careers</a></li>
-                            <li><a href="#contact">Contact</a></li>
-                        </ul>
-                    </div>
-                    
-                    <div class="footer-section">
-                        <h4>Resources</h4>
-                        <ul>
-                            <li><a href="#references">References</a></li>
-                            <li><a href="#documentation">Documentation</a></li>
-                            <li><a href="#support">Support</a></li>
-                        </ul>
-                    </div>
+                <div class="footer-section">
+                    <h4>Product</h4>
+                    <ul>
+                        <li><a href="#solution">Solution</a></li>
+                        <li><a href="#evidence">Evidence</a></li>
+                        <li><a href="#platform">Platform</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Company</h4>
+                    <ul>
+                        <li><a href="#careers">Careers</a></li>
+                        <li><a href="#contact">Contact</a></li>
+                    </ul>
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- switch the loading overlay to a white background with teal branding accents
- remove the Resources navigation/footer entries and drop the About link from the Company column
- rebalance footer layouts and drop the desktop body min-width so the site fits laptop and mobile viewports

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4053e39fc8321812e3ddac80ba0b5