### PR TITLE
Update hero CTA, contact form, and shared branding

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/main-styles.css">
     <link rel="stylesheet" href="css/components.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body>
     <nav class="main-nav">

--- a/contact.html
+++ b/contact.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/main-styles.css">
     <link rel="stylesheet" href="css/components.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body>
     <nav class="main-nav">
@@ -120,14 +121,16 @@
                             <h2>Tell Us About Your Challenges</h2>
                             <p>Share your current prior authorization pain points and we'll explore how CareFuse can address them.</p>
                             
-                            <form class="contact-form" action="https://formsubmit.co/yuri.braga@carefuseai.com" method="POST">
+                            <form class="contact-form" id="carefuse-contact-form" action="https://formsubmit.co/yuri.braga@carefuseai.com" method="POST">
                                 <input type="hidden" name="_subject" value="New CareFuse contact request">
                                 <input type="hidden" name="_captcha" value="false">
+                                <input type="hidden" name="_template" value="table">
+                                <input type="hidden" name="_replyto" id="replyToField" value="">
                                 <div class="form-group">
                                     <label for="name">Name *</label>
                                     <input type="text" id="name" name="name" required>
                                 </div>
-                                
+
                                 <div class="form-group">
                                     <label for="email">Email *</label>
                                     <input type="email" id="email" name="email" required>
@@ -227,6 +230,21 @@
     </footer>
 
     <script src="js/main.js"></script>
+    <script>
+        (function() {
+            const form = document.getElementById('carefuse-contact-form');
+            if (!form) return;
+
+            const emailField = document.getElementById('email');
+            const replyToField = document.getElementById('replyToField');
+
+            form.addEventListener('submit', function() {
+                if (replyToField && emailField) {
+                    replyToField.value = emailField.value;
+                }
+            });
+        })();
+    </script>
 </body>
 </html>
 

--- a/css/components.css
+++ b/css/components.css
@@ -1846,7 +1846,7 @@ img, svg, video {
 .logo-text {
     font-size: 1.4rem;
     font-weight: 700;
-    color: var(--text-primary);
+    color: var(--dark-cyan);
 }
 
 .logo-image {

--- a/index.html
+++ b/index.html
@@ -104,16 +104,6 @@
                     </div>
                 </div>
                 
-                <div class="hero-actions">
-                    <button class="btn btn-primary btn-large" onclick="openDemo()">
-                        <i class="fas fa-calendar-alt"></i>
-                        Request a Demo
-                    </button>
-                    <button class="btn btn-secondary btn-large" onclick="downloadSample()">
-                        <i class="fas fa-download"></i>
-                        See Sample Authorization Packet
-                    </button>
-                </div>
             </div>
         </div>
     </section>
@@ -976,7 +966,7 @@
                 </div>
                 
                 <div class="footer-bottom-content">
-                    <p>&copy; 2024 CareFuse. All rights reserved.</p>
+                    <p>&copy; 2025 CareFuse. All rights reserved.</p>
                     <div class="footer-bottom-links">
                         <a href="#privacy">Privacy Policy</a>
                         <a href="#terms">Terms of Service</a>


### PR DESCRIPTION
## Summary
- remove the hero section demo and sample packet buttons to streamline the landing page messaging
- refresh shared branding by tinting the navbar wordmark dark cyan, updating the footer copyright to 2025, and adding the favicon to secondary pages
- wire the contact form to include reply-to metadata for FormSubmit so messages arrive with the sender’s address

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e416c561a08321bae04049566a729a