### PR TITLE
Update knee replacement statcard and references

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,9 @@
                         <div class="stat-icon">
                             <i class="fas fa-chart-line"></i>
                         </div>
-                        <div class="stat-number">$18 Billion</div>
+                        <div class="stat-number">$9+ Billion</div>
                         <div class="stat-label">spent in the US per year</div>
-                        <div class="stat-description">in knee and hip arthroplasty every year <sup class="footnote"><a href="#ref2">[2]</a></sup></div>
+                        <div class="stat-description">in knee replacement every year for the surgery alone (not including revisions or readmissions). <sup class="footnote"><a href="#ref2">[2]</a></sup> This number is predicted to increase to $16.4 billion by 2032. <sup class="footnote"><a href="#ref3">[3]</a></sup></div>
                     </div>
 
                     <div class="stat-card">
@@ -91,7 +91,7 @@
                         </div>
                         <div class="stat-number">30%</div>
                         <div class="stat-label">of Total Knee Replacements</div>
-                        <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="#ref3">[3]</a></sup></div>
+                        <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="#ref5">[5]</a></sup></div>
                     </div>
 
                     <div class="stat-card">
@@ -140,7 +140,7 @@
                             <span class="stat-description">Minimum patient coverage required</span>
                         </div>
                     </div>
-                    <p class="card-description">Medicare's mandatory PROMs collection for TKA/THA shifts focus from volume to outcomes, with severe financial penalties for hospitals failing to demonstrate patient improvement.<sup class="footnote"><a href="#ref4">[4]</a></sup></p>
+                    <p class="card-description">Medicare's mandatory PROMs collection for TKA/THA shifts focus from volume to outcomes, with severe financial penalties for hospitals failing to demonstrate patient improvement.<sup class="footnote"><a href="#ref6">[6]</a></sup></p>
                 </div>
                 
                 <div class="problem-card">
@@ -165,7 +165,7 @@
                             <span class="stat-description">Uncertainty about surgical outcomes</span>
                         </div>
                     </div>
-                    <p class="card-description">Despite being one of the most common surgeries, TKA decisions remain "highly subjective and discretionary" with significant variation between orthopedic surgeons, rheumatologists, and primary care providers.<sup class="footnote"><a href="#ref5">[5]</a></sup></p>
+                    <p class="card-description">Despite being one of the most common surgeries, TKA decisions remain "highly subjective and discretionary" with significant variation between orthopedic surgeons, rheumatologists, and primary care providers.<sup class="footnote"><a href="#ref7">[7]</a></sup></p>
                 </div>
                 
                 <div class="problem-card">
@@ -190,7 +190,7 @@
                             <span class="stat-description">Transparent, reviewable decision-making</span>
                         </div>
                     </div>
-                    <p class="card-description">New state laws prohibit AI from making final prior authorization decisions without physician review, requiring transparent, explainable AI that bases decisions on individual patient data rather than population averages.<sup class="footnote"><a href="#ref6">[6]</a></sup></p>
+                    <p class="card-description">New state laws prohibit AI from making final prior authorization decisions without physician review, requiring transparent, explainable AI that bases decisions on individual patient data rather than population averages.<sup class="footnote"><a href="#ref8">[8]</a></sup></p>
                 </div>
                 
                 <div class="problem-card">
@@ -215,7 +215,7 @@
                             <span class="stat-description">Choice due to evidence uncertainty</span>
                         </div>
                     </div>
-                    <p class="card-description">While structured conservative care (education, exercise, weight management) can avoid up to 40% of TKAs, the lack of robust head-to-head comparison evidence makes surgery the default choice. This evidence gap prevents optimal patient-treatment matching.<sup class="footnote"><a href="#ref7">[7]</a></sup></p>
+                    <p class="card-description">While structured conservative care (education, exercise, weight management) can avoid up to 40% of TKAs, the lack of robust head-to-head comparison evidence makes surgery the default choice. This evidence gap prevents optimal patient-treatment matching.<sup class="footnote"><a href="#ref9">[9]</a></sup></p>
                 </div>
             </div>
         </div>
@@ -227,7 +227,7 @@
             <div class="section-header">
                 <span class="section-badge">CareFuse Solution</span>
                 <h2 class="section-title">Clinical Decision Support</h2>
-                <p class="section-description">Predict whether a member will achieve MCID (ΔWOMAC ≥ 10) at 12 months with transparent, explainable AI built for UM workflows.<sup class="footnote"><a href="#ref8">[8]</a></sup></p>
+                <p class="section-description">Predict whether a member will achieve MCID (ΔWOMAC ≥ 10) at 12 months with transparent, explainable AI built for UM workflows.<sup class="footnote"><a href="#ref10">[10]</a></sup></p>
             </div>
             
             <div class="solution-content">
@@ -286,7 +286,7 @@
 
                         <div class="tka-explanation">
                             <h4>About TKA Surgery</h4>
-                            <p><strong>Total knee arthroplasty (TKA) is an invasive surgery with risks and a lengthy recovery period. This software helps identify potentially ineffective surgeries before they occur to protect patient well-being.</strong><sup class="footnote"><a href="#ref9">[9]</a></sup></p>
+                            <p><strong>Total knee arthroplasty (TKA) is an invasive surgery with risks and a lengthy recovery period. This software helps identify potentially ineffective surgeries before they occur to protect patient well-being.</strong><sup class="footnote"><a href="#ref11">[11]</a></sup></p>
                         </div>
                         
                         <div class="prediction-sections">
@@ -593,7 +593,7 @@
             <div class="section-header">
                 <span class="section-badge">Compliance & Governance</span>
                 <h2 class="section-title">Regulatory Alignment</h2>
-                <p class="section-description">Built for healthcare compliance with comprehensive governance and audit capabilities, aligning with the CMS Interoperability & Prior Authorization Final Rule.<sup class="footnote"><a href="#ref10">[10]</a></sup></p>
+                <p class="section-description">Built for healthcare compliance with comprehensive governance and audit capabilities, aligning with the CMS Interoperability & Prior Authorization Final Rule.<sup class="footnote"><a href="#ref12">[12]</a></sup></p>
             </div>
             
             <div class="compliance-grid">
@@ -615,7 +615,7 @@
                     <div class="compliance-icon">
                         <i class="fas fa-file-alt"></i>
                     </div>
-                    <h3>NAIC AI Bulletin Alignment <sup class="footnote"><a href="#ref11">[11]</a></sup></h3>
+                    <h3>NAIC AI Bulletin Alignment <sup class="footnote"><a href="#ref13">[13]</a></sup></h3>
                     <ul>
                         <li>AIS Program support documentation</li>
                         <li>Detailed model cards and validation reports</li>
@@ -629,7 +629,7 @@
                     <div class="compliance-icon">
                         <i class="fas fa-balance-scale"></i>
                     </div>
-                    <h3>California AB-3030 <sup class="footnote"><a href="#ref12">[12]</a></sup></h3>
+                    <h3>California AB-3030 <sup class="footnote"><a href="#ref14">[14]</a></sup></h3>
                     <p>For member-facing clinical communications to California residents:</p>
                     <ul>
                         <li>Required AI disclaimers and human contact instructions</li>
@@ -865,29 +865,45 @@
                 <div class="reference-item" id="ref2">
                     <div class="ref-number">2</div>
                     <div class="ref-content">
-                        <p>ScienceDirect. Economic burden of knee and hip arthroplasty in younger patients.</p>
-                        <a href="https://www.sciencedirect.com/science/article/pii/S0883540325002529#:~:text=Over%20the%20last%20several%20decades,in%20younger%20patients%20%5B4%5D." class="ref-link" target="_blank" rel="noopener">ScienceDirect (2025)</a>
+                        <p>Harvard Health Publishing. How long will my hip or knee replacement last?</p>
+                        <a href="https://www.health.harvard.edu/blog/how-long-will-my-hip-or-knee-replacement-last-2018071914272" class="ref-link" target="_blank" rel="noopener">Harvard Health (2018)</a>
                     </div>
                 </div>
 
                 <div class="reference-item" id="ref3">
                     <div class="ref-number">3</div>
                     <div class="ref-content">
-                        <p>ScienceDirect. Dissatisfaction rates following total knee arthroplasty.</p>
-                        <a href="https://www.sciencedirect.com/science/article/pii/S1877056817303298" class="ref-link" target="_blank" rel="noopener">ScienceDirect (2017)</a>
+                        <p>Renub Research. Knee replacement market analysis and forecast.</p>
+                        <a href="https://www.renub.com/knee-replacement-market-p.php" class="ref-link" target="_blank" rel="noopener">Renub Research</a>
                     </div>
                 </div>
 
                 <div class="reference-item" id="ref4">
                     <div class="ref-number">4</div>
                     <div class="ref-content">
-                        <p>Centers for Medicare & Medicaid Services. THA/TKA patient-reported outcomes measure requirements.</p>
-                        <a href="https://qualitynet.cms.gov/inpatient/measures/tha-tka" class="ref-link" target="_blank" rel="noopener">CMS THA/TKA PRO-PM</a>
+                        <p>ScienceDirect. Economic burden of knee and hip arthroplasty in younger patients.</p>
+                        <a href="https://www.sciencedirect.com/science/article/pii/S0883540325002529#:~:text=Over%20the%20last%20several%20decades,in%20younger%20patients%20%5B4%5D." class="ref-link" target="_blank" rel="noopener">ScienceDirect (2025)</a>
                     </div>
                 </div>
 
                 <div class="reference-item" id="ref5">
                     <div class="ref-number">5</div>
+                    <div class="ref-content">
+                        <p>ScienceDirect. Dissatisfaction rates following total knee arthroplasty.</p>
+                        <a href="https://www.sciencedirect.com/science/article/pii/S1877056817303298" class="ref-link" target="_blank" rel="noopener">ScienceDirect (2017)</a>
+                    </div>
+                </div>
+
+                <div class="reference-item" id="ref6">
+                    <div class="ref-number">6</div>
+                    <div class="ref-content">
+                        <p>Centers for Medicare & Medicaid Services. THA/TKA patient-reported outcomes measure requirements.</p>
+                        <a href="https://qualitynet.cms.gov/inpatient/measures/tha-tka" class="ref-link" target="_blank" rel="noopener">CMS THA/TKA PRO-PM</a>
+                    </div>
+                </div>
+
+                <div class="reference-item" id="ref7">
+                    <div class="ref-number">7</div>
                     <div class="ref-content">
                         <p>Evidence on variation and subjectivity in TKA decision-making.</p>
                         <a href="https://bmchealthservres.biomedcentral.com/articles/10.1186/1472-6963-8-270" class="ref-link" target="_blank" rel="noopener">BMC Health Serv Res (2008)</a>
@@ -895,16 +911,16 @@
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref6">
-                    <div class="ref-number">6</div>
+                <div class="reference-item" id="ref8">
+                    <div class="ref-number">8</div>
                     <div class="ref-content">
                         <p>Cooley LLP. State artificial intelligence regulation tracker and analysis (2025).</p>
                         <a href="https://www.cooley.com/news/insight/2024/2024-10-29-us-state-ai-legislation-tracker" class="ref-link" target="_blank" rel="noopener">Cooley State AI Regulation Analysis</a>
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref7">
-                    <div class="ref-number">7</div>
+                <div class="reference-item" id="ref9">
+                    <div class="ref-number">9</div>
                     <div class="ref-content">
                         <p>Structured conservative care effectiveness and payer budget impact modeling for knee osteoarthritis.</p>
                         <a href="https://onlinelibrary.wiley.com/doi/10.1002/acr.24244" class="ref-link" target="_blank" rel="noopener">Arthritis Care &amp; Research</a>
@@ -912,8 +928,8 @@
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref8">
-                    <div class="ref-number">8</div>
+                <div class="reference-item" id="ref10">
+                    <div class="ref-number">10</div>
                     <div class="ref-content">
                         <p>Clement ND, et al. WOMAC MCID ≈ 10 at 12 months post-TKA.</p>
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30179956/" class="ref-link" target="_blank" rel="noopener">PubMed (PMID 30179956)</a>
@@ -921,8 +937,8 @@
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref9">
-                    <div class="ref-number">9</div>
+                <div class="reference-item" id="ref11">
+                    <div class="ref-number">11</div>
                     <div class="ref-content">
                         <p>Papakostidis C, Giannoudis PV, Watson JT, et al. Serious adverse events and 30-day readmission following elective TKA.</p>
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33789702/" class="ref-link" target="_blank" rel="noopener">PubMed (PMID 33789702)</a>
@@ -930,24 +946,24 @@
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref10">
-                    <div class="ref-number">10</div>
+                <div class="reference-item" id="ref12">
+                    <div class="ref-number">12</div>
                     <div class="ref-content">
                         <p>CMS Interoperability &amp; Prior Authorization Final Rule (CMS-0057-F) fact sheet.</p>
                         <a href="https://www.cms.gov/files/document/fact-sheet-cms-interoperability-and-prior-authorization-final-rule-cms-0057-f.pdf" class="ref-link" target="_blank" rel="noopener">CMS Fact Sheet (PDF)</a>
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref11">
-                    <div class="ref-number">11</div>
+                <div class="reference-item" id="ref13">
+                    <div class="ref-number">13</div>
                     <div class="ref-content">
                         <p>NAIC Model Bulletin on Artificial Intelligence Systems.</p>
                         <a href="https://content.naic.org/sites/default/files/cmte-h-big-data-artificial-intelligence-wg-ai-model-bulletin.pdf.pdf" class="ref-link" target="_blank" rel="noopener">NAIC AI Model Bulletin (PDF)</a>
                     </div>
                 </div>
 
-                <div class="reference-item" id="ref12">
-                    <div class="ref-number">12</div>
+                <div class="reference-item" id="ref14">
+                    <div class="ref-number">14</div>
                     <div class="ref-content">
                         <p>Medical Board of California. AB-3030 generative AI patient communication notice.</p>
                         <a href="https://www.mbc.ca.gov/Resources/Medical-Resources/GenAI-Notification.aspx" class="ref-link" target="_blank" rel="noopener">Medical Board of California - GenAI Notification</a>
@@ -986,7 +1002,7 @@
             
             <div class="footer-bottom">
                 <div class="footer-legal">
-                    <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="#ref12">[12]</a></sup></p>
+                    <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="#ref14">[14]</a></sup></p>
                 </div>
                 
                 <div class="footer-bottom-content">


### PR DESCRIPTION
## Summary
- update the hero stat card to show the revised $9+ billion knee replacement spend with updated supporting text
- add Harvard Health and Renub Research citations for the stat card and renumber all downstream references

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e5506dae388321b77371124f7f94d4