### PR TITLE
Streamline navigation and add standalone application page

### DIFF
--- a/application.html
+++ b/application.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CareFuse - Application</title>
+    <meta name="description" content="See how CareFuse's counterfactual AI delivers value for payers, providers, and patients across orthopedic workflows.">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <!-- Icons -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="css/main-styles.css" rel="stylesheet">
+    <link href="css/components.css" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="images/carefuse-logo.png">
+</head>
+<body class="teal-theme">
+    <div id="loading-screen" class="loading-screen">
+        <div class="loading-animation">
+            <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
+            <div class="loading-text">CareFuse</div>
+            <div class="loading-subtitle">Loading clinical platform...</div>
+        </div>
+    </div>
+
+    <div id="main-content" class="main-content">
+        <nav class="main-nav">
+            <div class="nav-container">
+                <div class="nav-logo">
+                    <a href="index.html" class="nav-logo-link">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
+                        <span class="logo-text">CareFuse</span>
+                    </a>
+                </div>
+
+                <div class="nav-links">
+                    <a href="index.html" class="nav-link">Home</a>
+                    <a href="problem.html" class="nav-link">Problem</a>
+                    <a href="solution.html" class="nav-link">Solution</a>
+                    <a href="evidence.html" class="nav-link">Evidence</a>
+                    <a href="application.html" class="nav-link active">Application</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <div class="dropdown-menu">
+                            <a href="platform.html" class="dropdown-item">Platform</a>
+                            <a href="compliance.html" class="dropdown-item">Compliance</a>
+                            <a href="impact.html" class="dropdown-item">Impact</a>
+                        </div>
+                    </div>
+
+                    <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Company</a>
+                        <div class="dropdown-menu">
+                            <a href="careers.html" class="dropdown-item">Careers</a>
+                            <a href="contact.html" class="dropdown-item">Contact</a>
+                            <a href="references.html" class="dropdown-item">References</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="nav-actions">
+                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                        <i class="fas fa-bars"></i>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <section id="application" class="application-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Application</span>
+                    <h2 class="section-title">Deploying Counterfactual Intelligence</h2>
+                    <p class="section-description">U.S. insurers face soaring costs from total knee arthroplasty (TKA), yet up to one-third of patients experience little to no improvement after surgery, leading to wasteful spending, patient dissatisfaction, and poor outcomes.<sup class="footnote"><a href="references.html#ref15">[15]</a></sup><sup class="footnote"><a href="references.html#ref16">[16]</a></sup></p>
+                </div>
+
+                <div class="application-grid">
+                    <div class="application-card">
+                        <div class="application-icon">
+                            <i class="fas fa-brain"></i>
+                        </div>
+                        <h3>Predictive Decision Support</h3>
+                        <ul class="application-list">
+                            <li>Delivers individualized counterfactual predictions showing outcomes with surgery versus conservative care.</li>
+                            <li>Achieves ~93% AUC accuracy on real-world pre- and post-operative data, ready for clinical deployment.</li>
+                            <li>Generates SHAP-based explanations to meet transparency, auditability, and fairness requirements.<sup class="footnote"><a href="references.html#ref22">[22]</a></sup></li>
+                            <li>Aligns with CMS’s 2025 prior authorization final rule, which mandates evidence-based, patient-specific justification for orthopedic procedures.<sup class="footnote"><a href="references.html#ref17">[17]</a></sup></li>
+                        </ul>
+                    </div>
+
+                    <div class="application-card">
+                        <div class="application-icon">
+                            <i class="fas fa-hospital-user"></i>
+                        </div>
+                        <h3>Optimizes Orthopedic Workflow</h3>
+                        <ul class="application-list">
+                            <li>Prioritizes “hot-lead” OA patients so surgical teams focus on members most likely to achieve meaningful benefit.</li>
+                            <li>Improves OR throughput and surgical ROI by elevating high-benefit cases—critical as CMS requires KOOS Jr. outcomes for reimbursement tracking.<sup class="footnote"><a href="references.html#ref18">[18]</a></sup><sup class="footnote"><a href="references.html#ref19">[19]</a></sup></li>
+                            <li>Reduces low-value specialist visits by steering low-benefit patients away from unnecessary imaging and consults.</li>
+                        </ul>
+                    </div>
+
+                    <div class="application-card">
+                        <div class="application-icon">
+                            <i class="fas fa-dna"></i>
+                        </div>
+                        <h3>Boosts Conservative Care Pathways</h3>
+                        <ul class="application-list">
+                            <li>Redirects low-benefit patients toward GLP-1-based weight management programs proven to improve OA outcomes.<sup class="footnote"><a href="references.html#ref20">[20]</a></sup><sup class="footnote"><a href="references.html#ref21">[21]</a></sup></li>
+                            <li>Promotes structured physical therapy and lifestyle programs that delay surgical need.</li>
+                            <li>Delivers AI-personalized education where patients compare surgical versus non-surgical benefit, powered by SHAP explanations.<sup class="footnote"><a href="references.html#ref22">[22]</a></sup></li>
+                            <li>Empowers shared decision-making that reduces regret and unnecessary interventions.<sup class="footnote"><a href="references.html#ref23">[23]</a></sup></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="application-outcomes">
+                    <div class="outcome-card">
+                        <i class="fas fa-piggy-bank"></i>
+                        <div>
+                            <h3>For Payers</h3>
+                            <p>Reduced spend on low-benefit TKA surgeries, fewer downstream costs, and transparent ROI tracking.</p>
+                        </div>
+                    </div>
+                    <div class="outcome-card">
+                        <i class="fas fa-user-md"></i>
+                        <div>
+                            <h3>For Providers</h3>
+                            <p>Higher outcome metrics, optimized OR utilization, and avoidance of poor-value care episodes.</p>
+                        </div>
+                    </div>
+                    <div class="outcome-card">
+                        <i class="fas fa-users"></i>
+                        <div>
+                            <h3>For Patients</h3>
+                            <p>Clearer choices, fewer unnecessary surgeries, and improved access to alternatives that deliver meaningful improvement.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="next-section-nav">
+            <a href="platform.html" class="btn btn-secondary">Next: Platform</a>
+        </div>
+
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-content">
+                    <div class="footer-brand">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
+                        <span class="footer-brand-text">CareFuse</span>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Product</h4>
+                        <ul>
+                            <li><a href="solution.html">Solution</a></li>
+                            <li><a href="evidence.html">Evidence</a></li>
+                            <li><a href="platform.html">Platform</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Company</h4>
+                        <ul>
+                            <li><a href="careers.html">Careers</a></li>
+                            <li><a href="contact.html">Contact</a></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="footer-bottom">
+                    <div class="footer-legal">
+                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
+                    </div>
+
+                    <div class="footer-bottom-content">
+                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/careers.html
+++ b/careers.html
@@ -20,24 +20,39 @@
             </div>
             
             <div class="nav-links">
-                <a href="index.html#problem" class="nav-link">Problem</a>
-                <a href="index.html#solution" class="nav-link">Solution</a>
-                <a href="index.html#evidence" class="nav-link">Evidence</a>
-                <a href="index.html#platform" class="nav-link">Platform</a>
-                <a href="index.html#impact" class="nav-link">Impact</a>
-                
+                <a href="index.html" class="nav-link">Home</a>
+                <a href="problem.html" class="nav-link">Problem</a>
+                <a href="solution.html" class="nav-link">Solution</a>
+                <a href="evidence.html" class="nav-link">Evidence</a>
+                <a href="application.html" class="nav-link">Application</a>
+
                 <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger">Company</a>
+                    <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                    <div class="dropdown-menu">
+                        <a href="platform.html" class="dropdown-item">Platform</a>
+                        <a href="compliance.html" class="dropdown-item">Compliance</a>
+                        <a href="impact.html" class="dropdown-item">Impact</a>
+                    </div>
+                </div>
+
+                <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                <div class="nav-dropdown">
+                    <a href="#" class="nav-link dropdown-trigger active">Company</a>
                     <div class="dropdown-menu">
                         <a href="careers.html" class="dropdown-item active">Careers</a>
                         <a href="contact.html" class="dropdown-item">Contact</a>
+                        <a href="references.html" class="dropdown-item">References</a>
                     </div>
                 </div>
-                
+
             </div>
-            
+
             <div class="nav-actions">
                 <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                    <i class="fas fa-bars"></i>
+                </button>
             </div>
         </div>
     </nav>

--- a/compliance.html
+++ b/compliance.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CareFuse - Transparent AI for Hip & Knee Prior Authorization</title>
-    <meta name="description" content="Clinical-grade AI for payer UM teams. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.">
+    <title>CareFuse - Compliance</title>
+    <meta name="description" content="Understand the governance, regulatory alignment, and safeguards powering CareFuse's payer-ready AI platform.">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,7 +22,6 @@
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body class="teal-theme">
-    <!-- Loading Screen -->
     <div id="loading-screen" class="loading-screen">
         <div class="loading-animation">
             <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
@@ -31,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Main Content -->
     <div id="main-content" class="main-content">
         <nav class="main-nav">
             <div class="nav-container">
@@ -43,17 +41,17 @@
                 </div>
 
                 <div class="nav-links">
-                    <a href="index.html" class="nav-link active">Home</a>
+                    <a href="index.html" class="nav-link">Home</a>
                     <a href="problem.html" class="nav-link">Problem</a>
                     <a href="solution.html" class="nav-link">Solution</a>
                     <a href="evidence.html" class="nav-link">Evidence</a>
                     <a href="application.html" class="nav-link">Application</a>
 
                     <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <a href="#" class="nav-link dropdown-trigger active">Implementation</a>
                         <div class="dropdown-menu">
                             <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
+                            <a href="compliance.html" class="dropdown-item active">Compliance</a>
                             <a href="impact.html" class="dropdown-item">Impact</a>
                         </div>
                     </div>
@@ -79,51 +77,87 @@
             </div>
         </nav>
 
-        <!-- Home / Hero Section -->
-        <section class="hero-section">
-            <div class="hero-container">
-                <div class="hero-content">
-                    <h1 class="hero-title">Transparent AI for Orthopedic Surgery Prediction</h1>
-                    <p class="hero-subtitle">CareFuse is the first company to build a counterfactual AI model for total knee arthroplasty (TKA), predicting individualized outcomes with and without surgery. With ~790k TKAs annually in the U.S., and 30% of patients gaining no benefit, our SHAP-explained platform empowers payers to identify the right moment for the right patient, reducing unnecessary surgeries and costs.</p>
+        <section class="compliance-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Compliance &amp; Governance</span>
+                    <h2 class="section-title">Regulatory Alignment</h2>
+                    <p class="section-description">Built for healthcare compliance with comprehensive governance and audit capabilities, aligning with the CMS Interoperability &amp; Prior Authorization Final Rule.<sup class="footnote"><a href="references.html#ref12">[12]</a></sup></p>
+                </div>
 
-                    <div class="hero-stats">
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-chart-line"></i>
-                            </div>
-                            <div class="stat-number">$9+ Billion</div>
-                            <div class="stat-label">spent in the US per year</div>
-                            <div class="stat-description">in knee replacement every year for the surgery alone (not including revisions or readmissions). <sup class="footnote"><a href="references.html#ref2">[2]</a></sup> This number is predicted to increase to $16.4 billion by 2032. <sup class="footnote"><a href="references.html#ref3">[3]</a></sup></div>
+                <div class="compliance-grid">
+                    <div class="compliance-card">
+                        <div class="compliance-icon">
+                            <i class="fas fa-shield-alt"></i>
                         </div>
-
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-procedures"></i>
-                            </div>
-                            <div class="stat-number">30%</div>
-                            <div class="stat-label">of Total Knee Replacements</div>
-                            <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="references.html#ref5">[5]</a></sup></div>
-                        </div>
-
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-shield-alt"></i>
-                            </div>
-                            <div class="stat-number">93%</div>
-                            <div class="stat-label">Model AUC</div>
-                            <div class="stat-description">Clinical prediction accuracy for MCID achievement at 12 months</div>
-                        </div>
+                        <h3>HIPAA/BAA Compliance</h3>
+                        <ul>
+                            <li>Signed Business Associate Agreements</li>
+                            <li>At-rest and in-transit encryption</li>
+                            <li>Least-privilege access controls</li>
+                            <li>Comprehensive audit logging</li>
+                            <li>Breach response procedures</li>
+                        </ul>
                     </div>
 
+                    <div class="compliance-card">
+                        <div class="compliance-icon">
+                            <i class="fas fa-file-alt"></i>
+                        </div>
+                        <h3>NAIC AI Bulletin Alignment <sup class="footnote"><a href="references.html#ref13">[13]</a></sup></h3>
+                        <ul>
+                            <li>AIS Program support documentation</li>
+                            <li>Detailed model cards and validation reports</li>
+                            <li>Subgroup and fairness testing</li>
+                            <li>Continuous monitoring plans</li>
+                            <li>Vendor due-diligence packages</li>
+                        </ul>
+                    </div>
+
+                    <div class="compliance-card">
+                        <div class="compliance-icon">
+                            <i class="fas fa-balance-scale"></i>
+                        </div>
+                        <h3>California AB-3030 <sup class="footnote"><a href="references.html#ref14">[14]</a></sup></h3>
+                        <p>For member-facing clinical communications to California residents:</p>
+                        <ul>
+                            <li>Required AI disclaimers and human contact instructions</li>
+                            <li>"Reviewed by licensed clinician" toggle to suppress disclaimers</li>
+                            <li>Compliance with GenAI patient communication requirements</li>
+                        </ul>
+                    </div>
+
+                    <div class="compliance-card">
+                        <div class="compliance-icon">
+                            <i class="fas fa-map-marker-alt"></i>
+                        </div>
+                        <h3>Colorado Readiness</h3>
+                        <p>Prepared for Colorado SB21-169 and SB24-205 requirements for plans operating in Colorado.</p>
+                    </div>
                 </div>
+
+                <div class="certification-badges">
+                    <div class="badge">
+                        <i class="fas fa-certificate"></i>
+                        <span>HIPAA Compliant</span>
+                    </div>
+                    <div class="badge">
+                        <i class="fas fa-shield-alt"></i>
+                        <span>SOC 2 Ready</span>
+                    </div>
+                    <div class="badge">
+                        <i class="fas fa-globe"></i>
+                        <span>ISO 27001 Ready</span>
+                    </div>
+                </div>
+
             </div>
         </section>
 
         <div class="next-section-nav">
-            <a href="problem.html" class="btn btn-secondary">Next: Problem</a>
+            <a href="impact.html" class="btn btn-secondary">Next: Impact</a>
         </div>
 
-        <!-- Footer -->
         <footer class="footer">
             <div class="footer-container">
                 <div class="footer-content">
@@ -163,31 +197,6 @@
         </footer>
     </div>
 
-    <!-- MCID Tooltip -->
-    <div id="mcid-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>MCID (Minimal Clinically Important Difference)</h4>
-            <p>The smallest change in a treatment outcome that a patient would identify as important. For WOMAC scores, ΔWOMAC ≥ 10 points represents meaningful clinical improvement.</p>
-        </div>
-    </div>
-
-    <!-- SHAP Tooltip -->
-    <div id="shap-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>SHAP (SHapley Additive exPlanations)</h4>
-            <p>A method to explain individual predictions by computing the contribution of each feature to the prediction. Provides transparent, interpretable AI explanations.</p>
-        </div>
-    </div>
-
-    <!-- PAS Tooltip -->
-    <div id="pas-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>PAS (Prior Authorization Support)</h4>
-            <p>HL7 FHIR implementation guide for electronic prior authorization workflows, enabling seamless integration between providers and payers.</p>
-        </div>
-    </div>
-
-    <!-- Scripts -->
     <script src="js/main.js"></script>
     <script src="js/calculator.js"></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -20,24 +20,39 @@
             </div>
             
             <div class="nav-links">
-                <a href="index.html#problem" class="nav-link">Problem</a>
-                <a href="index.html#solution" class="nav-link">Solution</a>
-                <a href="index.html#evidence" class="nav-link">Evidence</a>
-                <a href="index.html#platform" class="nav-link">Platform</a>
-                <a href="index.html#impact" class="nav-link">Impact</a>
-                
+                <a href="index.html" class="nav-link">Home</a>
+                <a href="problem.html" class="nav-link">Problem</a>
+                <a href="solution.html" class="nav-link">Solution</a>
+                <a href="evidence.html" class="nav-link">Evidence</a>
+                <a href="application.html" class="nav-link">Application</a>
+
                 <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger">Company</a>
+                    <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                    <div class="dropdown-menu">
+                        <a href="platform.html" class="dropdown-item">Platform</a>
+                        <a href="compliance.html" class="dropdown-item">Compliance</a>
+                        <a href="impact.html" class="dropdown-item">Impact</a>
+                    </div>
+                </div>
+
+                <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                <div class="nav-dropdown">
+                    <a href="#" class="nav-link dropdown-trigger active">Company</a>
                     <div class="dropdown-menu">
                         <a href="careers.html" class="dropdown-item">Careers</a>
                         <a href="contact.html" class="dropdown-item active">Contact</a>
+                        <a href="references.html" class="dropdown-item">References</a>
                     </div>
                 </div>
-                
+
             </div>
-            
+
             <div class="nav-actions">
                 <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                    <i class="fas fa-bars"></i>
+                </button>
             </div>
         </div>
     </nav>

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -304,6 +304,21 @@ body {
     font-size: 1rem;
 }
 
+.next-section-nav {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 4rem auto 6rem;
+    max-width: 1400px;
+    padding: 0 2rem;
+}
+
+.next-section-nav .btn {
+    box-shadow: var(--shadow-md);
+    min-width: 220px;
+    text-align: center;
+}
+
 /* Hero Section */
 .hero-section {
     padding: 120px 0 80px;
@@ -864,6 +879,124 @@ body {
 
 .feature-card p {
     color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+/* Application Section */
+.application-section {
+    padding: 80px 0;
+    background: var(--bg-secondary);
+}
+
+.application-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin-bottom: 3rem;
+}
+
+.application-card {
+    background: var(--white);
+    border-radius: var(--radius-xl);
+    padding: 2.5rem 2rem;
+    box-shadow: var(--shadow-lg);
+    position: relative;
+    overflow: hidden;
+}
+
+.application-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 2px solid transparent;
+    background: linear-gradient(135deg, rgba(31, 122, 122, 0.2), rgba(52, 199, 189, 0.1));
+    opacity: 0;
+    transition: var(--transition-fast);
+}
+
+.application-card:hover::after {
+    opacity: 1;
+}
+
+.application-card h3 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 1.25rem;
+}
+
+.application-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    background: var(--bg-teal-gradient);
+    color: var(--white);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: var(--shadow-teal);
+}
+
+.application-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.85rem;
+}
+
+.application-list li {
+    color: var(--text-secondary);
+    line-height: 1.7;
+    position: relative;
+    padding-left: 1.5rem;
+}
+
+.application-list li::before {
+    content: '\f0da';
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    position: absolute;
+    left: 0;
+    top: 0.2rem;
+    color: var(--primary-teal);
+}
+
+.application-outcomes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+}
+
+.outcome-card {
+    background: var(--white);
+    padding: 1.75rem;
+    border-radius: var(--radius-xl);
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    box-shadow: var(--shadow-md);
+}
+
+.outcome-card i {
+    font-size: 1.5rem;
+    color: var(--primary-teal);
+    margin-top: 0.25rem;
+}
+
+.outcome-card h3 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+}
+
+.outcome-card p {
+    color: var(--text-secondary);
+    margin: 0;
     line-height: 1.6;
 }
 

--- a/evidence.html
+++ b/evidence.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CareFuse - Transparent AI for Hip & Knee Prior Authorization</title>
-    <meta name="description" content="Clinical-grade AI for payer UM teams. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.">
+    <title>CareFuse - Evidence</title>
+    <meta name="description" content="Review the validation metrics, methodology, and internal testing that power CareFuse's counterfactual AI models.">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,7 +22,6 @@
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body class="teal-theme">
-    <!-- Loading Screen -->
     <div id="loading-screen" class="loading-screen">
         <div class="loading-animation">
             <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
@@ -31,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Main Content -->
     <div id="main-content" class="main-content">
         <nav class="main-nav">
             <div class="nav-container">
@@ -43,10 +41,10 @@
                 </div>
 
                 <div class="nav-links">
-                    <a href="index.html" class="nav-link active">Home</a>
+                    <a href="index.html" class="nav-link">Home</a>
                     <a href="problem.html" class="nav-link">Problem</a>
                     <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
+                    <a href="evidence.html" class="nav-link active">Evidence</a>
                     <a href="application.html" class="nav-link">Application</a>
 
                     <div class="nav-dropdown">
@@ -79,51 +77,71 @@
             </div>
         </nav>
 
-        <!-- Home / Hero Section -->
-        <section class="hero-section">
-            <div class="hero-container">
-                <div class="hero-content">
-                    <h1 class="hero-title">Transparent AI for Orthopedic Surgery Prediction</h1>
-                    <p class="hero-subtitle">CareFuse is the first company to build a counterfactual AI model for total knee arthroplasty (TKA), predicting individualized outcomes with and without surgery. With ~790k TKAs annually in the U.S., and 30% of patients gaining no benefit, our SHAP-explained platform empowers payers to identify the right moment for the right patient, reducing unnecessary surgeries and costs.</p>
+        <section id="evidence" class="evidence-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <div class="section-badge">Clinical Evidence</div>
+                    <h2 class="section-title">Validation &amp; Performance</h2>
+                    <p class="section-description">At CareFuse, we've built a calibrated, explainable logistic-regression model (OAI: demographics + WOMAC) that estimates a TKA patient's probability of achieving MCID and generates a counterfactual for conservative care using propensity-score weighting. Across 50 multi-seed holdout splits it achieves AUC ≈ 0.93, with transparent calibration/thresholding and SHAP explanations suited for clinical review.</p>
+                </div>
 
-                    <div class="hero-stats">
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-chart-line"></i>
-                            </div>
-                            <div class="stat-number">$9+ Billion</div>
-                            <div class="stat-label">spent in the US per year</div>
-                            <div class="stat-description">in knee replacement every year for the surgery alone (not including revisions or readmissions). <sup class="footnote"><a href="references.html#ref2">[2]</a></sup> This number is predicted to increase to $16.4 billion by 2032. <sup class="footnote"><a href="references.html#ref3">[3]</a></sup></div>
+                <div class="data-inputs-callout">
+                    <div class="callout-card">
+                        <div class="callout-icon">
+                            <i class="fas fa-clipboard-list"></i>
+                        </div>
+                        <div class="callout-content">
+                            <h3>How we generate a prediction</h3>
+                            <p>This tool can generate a personalized prediction using information the patient can readily provide (basic demographics and medical history) together with responses to an internationally validated arthritis questionnaire <span class="info-tooltip" data-tooltip="Refers to widely used instruments in osteoarthritis research and clinical practice"><i class="fas fa-info-circle"></i></span>. No imaging or specialized tests are required for the demo.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="validation-highlights">
+                    <h3>Validation Highlights</h3>
+                    <div class="headline-metrics">
+                        <div class="metric-card">
+                            <div class="metric-number">Up to 97%</div>
+                            <div class="metric-label">Accuracy</div>
                         </div>
 
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-procedures"></i>
-                            </div>
-                            <div class="stat-number">30%</div>
-                            <div class="stat-label">of Total Knee Replacements</div>
-                            <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="references.html#ref5">[5]</a></sup></div>
+                        <div class="metric-card">
+                            <div class="metric-number">AUC 0.93</div>
+                            <div class="metric-label">TKA pathway</div>
                         </div>
 
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-shield-alt"></i>
-                            </div>
-                            <div class="stat-number">93%</div>
-                            <div class="stat-label">Model AUC</div>
-                            <div class="stat-description">Clinical prediction accuracy for MCID achievement at 12 months</div>
+                        <div class="metric-card">
+                            <div class="metric-number">AUC 0.87</div>
+                            <div class="metric-label">Conservative pathway</div>
+                        </div>
+
+                        <div class="metric-card">
+                            <div class="metric-number">Sensitivity</div>
+                            <div class="metric-label">to non-MCID procedures</div>
                         </div>
                     </div>
 
+                    <div class="validation-footnote">
+                        <p>Internal validation. Performance depends on thresholds and population. For demonstration only; not a coverage determination.</p>
+                        <a href="#methods" class="see-methods-link">See methods</a>
+                    </div>
                 </div>
+
+                <div id="methods" class="methods-section">
+                    <h3>Methods</h3>
+                    <div class="methods-content">
+                        <p>Our model uses logistic regression with demographics and WOMAC scores from the OAI dataset. We completed a live pilot with Hapvida (15.7M policyholders) to demonstrate feasibility and workflow integration. In the U.S., our pilot would train a new model on your de-identified data using the same pipeline and deploy a secure, metered API with audit logging.</p>
+                        <p>CareFuse is represented by Gunderson Dettmer, and our product is built under the FDA non-device CDS exemption.</p>
+                    </div>
+                </div>
+
             </div>
         </section>
 
         <div class="next-section-nav">
-            <a href="problem.html" class="btn btn-secondary">Next: Problem</a>
+            <a href="application.html" class="btn btn-secondary">Next: Application</a>
         </div>
 
-        <!-- Footer -->
         <footer class="footer">
             <div class="footer-container">
                 <div class="footer-content">
@@ -163,31 +181,6 @@
         </footer>
     </div>
 
-    <!-- MCID Tooltip -->
-    <div id="mcid-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>MCID (Minimal Clinically Important Difference)</h4>
-            <p>The smallest change in a treatment outcome that a patient would identify as important. For WOMAC scores, ΔWOMAC ≥ 10 points represents meaningful clinical improvement.</p>
-        </div>
-    </div>
-
-    <!-- SHAP Tooltip -->
-    <div id="shap-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>SHAP (SHapley Additive exPlanations)</h4>
-            <p>A method to explain individual predictions by computing the contribution of each feature to the prediction. Provides transparent, interpretable AI explanations.</p>
-        </div>
-    </div>
-
-    <!-- PAS Tooltip -->
-    <div id="pas-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>PAS (Prior Authorization Support)</h4>
-            <p>HL7 FHIR implementation guide for electronic prior authorization workflows, enabling seamless integration between providers and payers.</p>
-        </div>
-    </div>
-
-    <!-- Scripts -->
     <script src="js/main.js"></script>
     <script src="js/calculator.js"></script>
 </body>

--- a/impact.html
+++ b/impact.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CareFuse - Transparent AI for Hip & Knee Prior Authorization</title>
-    <meta name="description" content="Clinical-grade AI for payer UM teams. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.">
+    <title>CareFuse - Impact</title>
+    <meta name="description" content="Model your avoided surgeries, medical savings, and ROI with the CareFuse decision support platform.">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,7 +22,6 @@
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body class="teal-theme">
-    <!-- Loading Screen -->
     <div id="loading-screen" class="loading-screen">
         <div class="loading-animation">
             <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
@@ -31,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Main Content -->
     <div id="main-content" class="main-content">
         <nav class="main-nav">
             <div class="nav-container">
@@ -43,18 +41,18 @@
                 </div>
 
                 <div class="nav-links">
-                    <a href="index.html" class="nav-link active">Home</a>
+                    <a href="index.html" class="nav-link">Home</a>
                     <a href="problem.html" class="nav-link">Problem</a>
                     <a href="solution.html" class="nav-link">Solution</a>
                     <a href="evidence.html" class="nav-link">Evidence</a>
                     <a href="application.html" class="nav-link">Application</a>
 
                     <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <a href="#" class="nav-link dropdown-trigger active">Implementation</a>
                         <div class="dropdown-menu">
                             <a href="platform.html" class="dropdown-item">Platform</a>
                             <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
+                            <a href="impact.html" class="dropdown-item active">Impact</a>
                         </div>
                     </div>
 
@@ -79,51 +77,81 @@
             </div>
         </nav>
 
-        <!-- Home / Hero Section -->
-        <section class="hero-section">
-            <div class="hero-container">
-                <div class="hero-content">
-                    <h1 class="hero-title">Transparent AI for Orthopedic Surgery Prediction</h1>
-                    <p class="hero-subtitle">CareFuse is the first company to build a counterfactual AI model for total knee arthroplasty (TKA), predicting individualized outcomes with and without surgery. With ~790k TKAs annually in the U.S., and 30% of patients gaining no benefit, our SHAP-explained platform empowers payers to identify the right moment for the right patient, reducing unnecessary surgeries and costs.</p>
+        <section id="impact" class="impact-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Impact &amp; ROI</span>
+                    <h2 class="section-title">Financial Impact Calculator</h2>
+                    <p class="section-description">Estimate the financial impact of CareFuse on your utilization management operations.</p>
+                </div>
 
-                    <div class="hero-stats">
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-chart-line"></i>
-                            </div>
-                            <div class="stat-number">$9+ Billion</div>
-                            <div class="stat-label">spent in the US per year</div>
-                            <div class="stat-description">in knee replacement every year for the surgery alone (not including revisions or readmissions). <sup class="footnote"><a href="references.html#ref2">[2]</a></sup> This number is predicted to increase to $16.4 billion by 2032. <sup class="footnote"><a href="references.html#ref3">[3]</a></sup></div>
+                <div class="roi-calculator">
+                    <div class="calculator-inputs">
+                        <div class="input-group">
+                            <label for="monthly-volume">Monthly TKA/THA PA Volume</label>
+                            <input type="number" id="monthly-volume" value="150" min="1">
                         </div>
 
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-procedures"></i>
-                            </div>
-                            <div class="stat-number">30%</div>
-                            <div class="stat-label">of Total Knee Replacements</div>
-                            <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="references.html#ref5">[5]</a></sup></div>
+                        <div class="input-group">
+                            <label for="approval-rate">Baseline Approval Rate (%)</label>
+                            <input type="range" id="approval-rate" min="60" max="95" value="85">
+                            <span class="range-value">85%</span>
                         </div>
 
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-shield-alt"></i>
-                            </div>
-                            <div class="stat-number">93%</div>
-                            <div class="stat-label">Model AUC</div>
-                            <div class="stat-description">Clinical prediction accuracy for MCID achievement at 12 months</div>
+                        <div class="input-group">
+                            <label for="low-benefit">% Predicted Low Benefit</label>
+                            <input type="range" id="low-benefit" min="10" max="40" value="25">
+                            <span class="range-value">25%</span>
+                        </div>
+
+                        <div class="input-group">
+                            <label for="episode-cost">Average Episode Cost ($)</label>
+                            <input type="number" id="episode-cost" value="25000" min="10000">
                         </div>
                     </div>
 
+                    <div class="calculator-results">
+                        <div class="result-card">
+                            <div class="result-icon">
+                                <i class="fas fa-calculator"></i>
+                            </div>
+                            <div class="result-value" id="avoided-surgeries">38</div>
+                            <div class="result-label">Avoided Surgeries/Year</div>
+                        </div>
+
+                        <div class="result-card">
+                            <div class="result-icon">
+                                <i class="fas fa-dollar-sign"></i>
+                            </div>
+                            <div class="result-value" id="medical-savings">$950,000</div>
+                            <div class="result-label">Annual Medical Savings</div>
+                        </div>
+
+                        <div class="result-card">
+                            <div class="result-icon">
+                                <i class="fas fa-clock"></i>
+                            </div>
+                            <div class="result-value" id="admin-savings">$75,000</div>
+                            <div class="result-label">Admin Savings</div>
+                        </div>
+
+                        <div class="result-card">
+                            <div class="result-icon">
+                                <i class="fas fa-chart-line"></i>
+                            </div>
+                            <div class="result-value" id="net-roi">$1,025,000</div>
+                            <div class="result-label">Net Annual ROI</div>
+                        </div>
+                    </div>
                 </div>
+
             </div>
         </section>
 
         <div class="next-section-nav">
-            <a href="problem.html" class="btn btn-secondary">Next: Problem</a>
+            <a href="roadmap.html" class="btn btn-secondary">Next: Roadmap</a>
         </div>
 
-        <!-- Footer -->
         <footer class="footer">
             <div class="footer-container">
                 <div class="footer-content">
@@ -163,31 +191,6 @@
         </footer>
     </div>
 
-    <!-- MCID Tooltip -->
-    <div id="mcid-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>MCID (Minimal Clinically Important Difference)</h4>
-            <p>The smallest change in a treatment outcome that a patient would identify as important. For WOMAC scores, ΔWOMAC ≥ 10 points represents meaningful clinical improvement.</p>
-        </div>
-    </div>
-
-    <!-- SHAP Tooltip -->
-    <div id="shap-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>SHAP (SHapley Additive exPlanations)</h4>
-            <p>A method to explain individual predictions by computing the contribution of each feature to the prediction. Provides transparent, interpretable AI explanations.</p>
-        </div>
-    </div>
-
-    <!-- PAS Tooltip -->
-    <div id="pas-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>PAS (Prior Authorization Support)</h4>
-            <p>HL7 FHIR implementation guide for electronic prior authorization workflows, enabling seamless integration between providers and payers.</p>
-        </div>
-    </div>
-
-    <!-- Scripts -->
     <script src="js/main.js"></script>
     <script src="js/calculator.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -82,26 +82,30 @@ function initializeNavigation() {
 
 function updateActiveNavLink() {
     const sections = document.querySelectorAll('section[id]');
-    const navLinks = document.querySelectorAll('.nav-links a');
-    
+    const navLinks = document.querySelectorAll('.nav-links a[href^="#"]');
+
+    if (!sections.length || !navLinks.length) {
+        return;
+    }
+
     let current = '';
-    
+
     sections.forEach(section => {
         const sectionTop = section.offsetTop;
         const sectionHeight = section.clientHeight;
-        
+
         if (window.scrollY >= sectionTop - 200) {
             current = section.getAttribute('id');
         }
     });
-    
+
     navLinks.forEach(link => {
         link.classList.remove('active');
         if (link.getAttribute('href') === `#${current}`) {
             link.classList.add('active');
         }
     });
-    
+
     currentSection = current;
 }
 

--- a/platform.html
+++ b/platform.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CareFuse - Transparent AI for Hip & Knee Prior Authorization</title>
-    <meta name="description" content="Clinical-grade AI for payer UM teams. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.">
+    <title>CareFuse - Platform</title>
+    <meta name="description" content="Discover how CareFuse integrates with PAS workflows, governance tooling, and payer infrastructure.">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,7 +22,6 @@
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body class="teal-theme">
-    <!-- Loading Screen -->
     <div id="loading-screen" class="loading-screen">
         <div class="loading-animation">
             <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
@@ -31,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Main Content -->
     <div id="main-content" class="main-content">
         <nav class="main-nav">
             <div class="nav-container">
@@ -43,16 +41,16 @@
                 </div>
 
                 <div class="nav-links">
-                    <a href="index.html" class="nav-link active">Home</a>
+                    <a href="index.html" class="nav-link">Home</a>
                     <a href="problem.html" class="nav-link">Problem</a>
                     <a href="solution.html" class="nav-link">Solution</a>
                     <a href="evidence.html" class="nav-link">Evidence</a>
                     <a href="application.html" class="nav-link">Application</a>
 
                     <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <a href="#" class="nav-link dropdown-trigger active">Implementation</a>
                         <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
+                            <a href="platform.html" class="dropdown-item active">Platform</a>
                             <a href="compliance.html" class="dropdown-item">Compliance</a>
                             <a href="impact.html" class="dropdown-item">Impact</a>
                         </div>
@@ -79,51 +77,106 @@
             </div>
         </nav>
 
-        <!-- Home / Hero Section -->
-        <section class="hero-section">
-            <div class="hero-container">
-                <div class="hero-content">
-                    <h1 class="hero-title">Transparent AI for Orthopedic Surgery Prediction</h1>
-                    <p class="hero-subtitle">CareFuse is the first company to build a counterfactual AI model for total knee arthroplasty (TKA), predicting individualized outcomes with and without surgery. With ~790k TKAs annually in the U.S., and 30% of patients gaining no benefit, our SHAP-explained platform empowers payers to identify the right moment for the right patient, reducing unnecessary surgeries and costs.</p>
+        <section id="platform" class="platform-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Platform &amp; Integration</span>
+                    <h2 class="section-title">Authorization Plugin</h2>
+                    <p class="section-description">Seamless integration with existing UM workflows through Da Vinci PAS and FHIR R4 compliance.<sup class="footnote"><a href="references.html#ref1">[1]</a></sup></p>
+                </div>
 
-                    <div class="hero-stats">
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-chart-line"></i>
+                <div class="integration-diagram">
+                    <div class="integration-flow">
+                        <div class="flow-step">
+                            <div class="step-icon">
+                                <i class="fas fa-hospital"></i>
                             </div>
-                            <div class="stat-number">$9+ Billion</div>
-                            <div class="stat-label">spent in the US per year</div>
-                            <div class="stat-description">in knee replacement every year for the surgery alone (not including revisions or readmissions). <sup class="footnote"><a href="references.html#ref2">[2]</a></sup> This number is predicted to increase to $16.4 billion by 2032. <sup class="footnote"><a href="references.html#ref3">[3]</a></sup></div>
+                            <div class="step-label">EHR/Portal</div>
                         </div>
-
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-procedures"></i>
+                        <div class="flow-arrow">→</div>
+                        <div class="flow-step">
+                            <div class="step-icon">
+                                <i class="fas fa-exchange-alt"></i>
                             </div>
-                            <div class="stat-number">30%</div>
-                            <div class="stat-label">of Total Knee Replacements</div>
-                            <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="references.html#ref5">[5]</a></sup></div>
+                            <div class="step-label">Da Vinci PAS</div>
                         </div>
-
-                        <div class="stat-card">
-                            <div class="stat-icon">
+                        <div class="flow-arrow">→</div>
+                        <div class="flow-step active">
+                            <div class="step-icon">
+                                <i class="fas fa-brain"></i>
+                            </div>
+                            <div class="step-label">CareFuse</div>
+                        </div>
+                        <div class="flow-arrow">→</div>
+                        <div class="flow-step">
+                            <div class="step-icon">
                                 <i class="fas fa-shield-alt"></i>
                             </div>
-                            <div class="stat-number">93%</div>
-                            <div class="stat-label">Model AUC</div>
-                            <div class="stat-description">Clinical prediction accuracy for MCID achievement at 12 months</div>
+                            <div class="step-label">Payer System</div>
                         </div>
                     </div>
-
+                    <p class="integration-note">CareFuse creates clinical attachments and rationale within the standard PAS workflow</p>
                 </div>
+
+                <div class="platform-features">
+                    <div class="feature-grid">
+                        <div class="platform-feature">
+                            <div class="feature-icon">
+                                <i class="fas fa-id-card"></i>
+                            </div>
+                            <h3>Versioned Model Card</h3>
+                            <p>Complete model documentation with version control and performance tracking</p>
+                        </div>
+
+                        <div class="platform-feature">
+                            <div class="feature-icon">
+                                <i class="fas fa-history"></i>
+                            </div>
+                            <h3>Audit Logs</h3>
+                            <p>Comprehensive audit trail for all predictions and decisions</p>
+                        </div>
+
+                        <div class="platform-feature">
+                            <div class="feature-icon">
+                                <i class="fas fa-database"></i>
+                            </div>
+                            <h3>Data Provenance</h3>
+                            <p>Full traceability of data sources and processing steps</p>
+                        </div>
+
+                        <div class="platform-feature">
+                            <div class="feature-icon">
+                                <i class="fas fa-chart-line"></i>
+                            </div>
+                            <h3>Drift &amp; Bias Monitoring</h3>
+                            <p>Continuous monitoring for model performance and fairness</p>
+                        </div>
+
+                        <div class="platform-feature">
+                            <div class="feature-icon">
+                                <i class="fas fa-users"></i>
+                            </div>
+                            <h3>Role-Based Access</h3>
+                            <p>Granular permissions and access controls for different user roles</p>
+                        </div>
+
+                        <div class="platform-feature">
+                            <div class="feature-icon">
+                                <i class="fas fa-code"></i>
+                            </div>
+                            <h3>FHIR R4 Compliance</h3>
+                            <p>Generate FHIR R4 resources conformant with Da Vinci PAS (FHIR→X12 278)<sup class="footnote"><a href="references.html#ref1">[1]</a></sup></p>
+                        </div>
+                    </div>
+                </div>
+
             </div>
         </section>
 
         <div class="next-section-nav">
-            <a href="problem.html" class="btn btn-secondary">Next: Problem</a>
+            <a href="compliance.html" class="btn btn-secondary">Next: Compliance</a>
         </div>
 
-        <!-- Footer -->
         <footer class="footer">
             <div class="footer-container">
                 <div class="footer-content">
@@ -163,31 +216,6 @@
         </footer>
     </div>
 
-    <!-- MCID Tooltip -->
-    <div id="mcid-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>MCID (Minimal Clinically Important Difference)</h4>
-            <p>The smallest change in a treatment outcome that a patient would identify as important. For WOMAC scores, ΔWOMAC ≥ 10 points represents meaningful clinical improvement.</p>
-        </div>
-    </div>
-
-    <!-- SHAP Tooltip -->
-    <div id="shap-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>SHAP (SHapley Additive exPlanations)</h4>
-            <p>A method to explain individual predictions by computing the contribution of each feature to the prediction. Provides transparent, interpretable AI explanations.</p>
-        </div>
-    </div>
-
-    <!-- PAS Tooltip -->
-    <div id="pas-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>PAS (Prior Authorization Support)</h4>
-            <p>HL7 FHIR implementation guide for electronic prior authorization workflows, enabling seamless integration between providers and payers.</p>
-        </div>
-    </div>
-
-    <!-- Scripts -->
     <script src="js/main.js"></script>
     <script src="js/calculator.js"></script>
 </body>

--- a/problem.html
+++ b/problem.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CareFuse - The Perfect Storm</title>
+    <meta name="description" content="Explore the regulatory, clinical, and financial pressures reshaping total knee arthroplasty decisions.">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <!-- Icons -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="css/main-styles.css" rel="stylesheet">
+    <link href="css/components.css" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="images/carefuse-logo.png">
+</head>
+<body class="teal-theme">
+    <div id="loading-screen" class="loading-screen">
+        <div class="loading-animation">
+            <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
+            <div class="loading-text">CareFuse</div>
+            <div class="loading-subtitle">Loading clinical platform...</div>
+        </div>
+    </div>
+
+    <div id="main-content" class="main-content">
+        <nav class="main-nav">
+            <div class="nav-container">
+                <div class="nav-logo">
+                    <a href="index.html" class="nav-logo-link">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
+                        <span class="logo-text">CareFuse</span>
+                    </a>
+                </div>
+
+                <div class="nav-links">
+                    <a href="index.html" class="nav-link">Home</a>
+                    <a href="problem.html" class="nav-link active">Problem</a>
+                    <a href="solution.html" class="nav-link">Solution</a>
+                    <a href="evidence.html" class="nav-link">Evidence</a>
+                    <a href="application.html" class="nav-link">Application</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <div class="dropdown-menu">
+                            <a href="platform.html" class="dropdown-item">Platform</a>
+                            <a href="compliance.html" class="dropdown-item">Compliance</a>
+                            <a href="impact.html" class="dropdown-item">Impact</a>
+                        </div>
+                    </div>
+
+                    <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Company</a>
+                        <div class="dropdown-menu">
+                            <a href="careers.html" class="dropdown-item">Careers</a>
+                            <a href="contact.html" class="dropdown-item">Contact</a>
+                            <a href="references.html" class="dropdown-item">References</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="nav-actions">
+                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                        <i class="fas fa-bars"></i>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <section id="problem" class="problem-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Current Challenges</span>
+                    <h2 class="section-title">The Perfect Storm: Four Converging Healthcare Forces</h2>
+                    <p class="section-description">The U.S. healthcare system is experiencing unprecedented regulatory convergence that's transforming how knee replacement decisions are made, measured, and governed. Four critical forces are creating both urgent challenges and massive opportunities for transparent, evidence-based prior authorization.</p>
+                </div>
+
+                <div class="problem-grid">
+                    <div class="problem-card">
+                        <div class="card-icon">
+                            <i class="fas fa-chart-bar"></i>
+                        </div>
+                        <h3>The Accountability Challenge</h3>
+                        <div class="accountability-stats">
+                            <div class="accountability-item">
+                                <span class="stat-number">25%</span>
+                                <span class="stat-label">APU Reduction Penalty</span>
+                                <span class="stat-description">For non-compliance with PROMs collection</span>
+                            </div>
+                            <div class="accountability-item">
+                                <span class="stat-number">2027</span>
+                                <span class="stat-label">Public Reporting</span>
+                                <span class="stat-description">CMS will publicly report improvement rates</span>
+                            </div>
+                            <div class="accountability-item">
+                                <span class="stat-number">50%</span>
+                                <span class="stat-label">Data Collection</span>
+                                <span class="stat-description">Minimum patient coverage required</span>
+                            </div>
+                        </div>
+                        <p class="card-description">Medicare's mandatory PROMs collection for TKA/THA shifts focus from volume to outcomes, with severe financial penalties for hospitals failing to demonstrate patient improvement.<sup class="footnote"><a href="references.html#ref6">[6]</a></sup></p>
+                    </div>
+
+                    <div class="problem-card">
+                        <div class="card-icon">
+                            <i class="fas fa-question-circle"></i>
+                        </div>
+                        <h3>The Subjectivity Problem</h3>
+                        <div class="subjectivity-stats">
+                            <div class="subjectivity-item">
+                                <span class="stat-number">High</span>
+                                <span class="stat-label">Physician Variation</span>
+                                <span class="stat-description">Significant disagreement on TKA indications</span>
+                            </div>
+                            <div class="subjectivity-item">
+                                <span class="stat-number">Elusive</span>
+                                <span class="stat-label">Surgical Readiness</span>
+                                <span class="stat-description">Guidelines remain unclear and subjective</span>
+                            </div>
+                            <div class="subjectivity-item">
+                                <span class="stat-number">Conflict</span>
+                                <span class="stat-label">Patient Decisions</span>
+                                <span class="stat-description">Uncertainty about surgical outcomes</span>
+                            </div>
+                        </div>
+                        <p class="card-description">Despite being one of the most common surgeries, TKA decisions remain "highly subjective and discretionary" with significant variation between orthopedic surgeons, rheumatologists, and primary care providers.<sup class="footnote"><a href="references.html#ref7">[7]</a></sup></p>
+                    </div>
+
+                    <div class="problem-card">
+                        <div class="card-icon">
+                            <i class="fas fa-eye"></i>
+                        </div>
+                        <h3>The Transparency Requirement</h3>
+                        <div class="transparency-stats">
+                            <div class="transparency-item">
+                                <span class="stat-number">6+</span>
+                                <span class="stat-label">States with AI Laws</span>
+                                <span class="stat-description">Requiring physician oversight of AI decisions</span>
+                            </div>
+                            <div class="transparency-item">
+                                <span class="stat-number">Individual</span>
+                                <span class="stat-label">Data Requirement</span>
+                                <span class="stat-description">AI must use patient-specific, not group data</span>
+                            </div>
+                            <div class="transparency-item">
+                                <span class="stat-number">Explainable</span>
+                                <span class="stat-label">AI Mandate</span>
+                                <span class="stat-description">Transparent, reviewable decision-making</span>
+                            </div>
+                        </div>
+                        <p class="card-description">New state laws prohibit AI from making final prior authorization decisions without physician review, requiring transparent, explainable AI that bases decisions on individual patient data rather than population averages.<sup class="footnote"><a href="references.html#ref8">[8]</a></sup></p>
+                    </div>
+
+                    <div class="problem-card">
+                        <div class="card-icon">
+                            <i class="fas fa-balance-scale"></i>
+                        </div>
+                        <h3>The Evidence Gap Problem</h3>
+                        <div class="conservative-stats">
+                            <div class="conservative-item">
+                                <span class="stat-number">40%</span>
+                                <span class="stat-label">TKAs Avoidable</span>
+                                <span class="stat-description">With structured conservative care</span>
+                            </div>
+                            <div class="conservative-item">
+                                <span class="stat-number">Weak</span>
+                                <span class="stat-label">Head-to-Head Evidence</span>
+                                <span class="stat-description">Conservative vs. surgical comparisons</span>
+                            </div>
+                            <div class="conservative-item">
+                                <span class="stat-number">Default</span>
+                                <span class="stat-label">TKA Becomes Default</span>
+                                <span class="stat-description">Choice due to evidence uncertainty</span>
+                            </div>
+                        </div>
+                        <p class="card-description">While structured conservative care (education, exercise, weight management) can avoid up to 40% of TKAs, the lack of robust head-to-head comparison evidence makes surgery the default choice. This evidence gap prevents optimal patient-treatment matching.<sup class="footnote"><a href="references.html#ref9">[9]</a></sup></p>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+        <div class="next-section-nav">
+            <a href="solution.html" class="btn btn-secondary">Next: Solution</a>
+        </div>
+
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-content">
+                    <div class="footer-brand">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
+                        <span class="footer-brand-text">CareFuse</span>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Product</h4>
+                        <ul>
+                            <li><a href="solution.html">Solution</a></li>
+                            <li><a href="evidence.html">Evidence</a></li>
+                            <li><a href="platform.html">Platform</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Company</h4>
+                        <ul>
+                            <li><a href="careers.html">Careers</a></li>
+                            <li><a href="contact.html">Contact</a></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="footer-bottom">
+                    <div class="footer-legal">
+                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
+                    </div>
+
+                    <div class="footer-bottom-content">
+                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script src="js/main.js"></script>
+    <script src="js/calculator.js"></script>
+</body>
+</html>

--- a/references.html
+++ b/references.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CareFuse - References</title>
+    <meta name="description" content="Scientific, regulatory, and clinical references supporting the CareFuse platform and application insights.">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <!-- Icons -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="css/main-styles.css" rel="stylesheet">
+    <link href="css/components.css" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="images/carefuse-logo.png">
+</head>
+<body class="teal-theme">
+    <div id="loading-screen" class="loading-screen">
+        <div class="loading-animation">
+            <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
+            <div class="loading-text">CareFuse</div>
+            <div class="loading-subtitle">Loading clinical platform...</div>
+        </div>
+    </div>
+
+    <div id="main-content" class="main-content">
+        <nav class="main-nav">
+            <div class="nav-container">
+                <div class="nav-logo">
+                    <a href="index.html" class="nav-logo-link">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
+                        <span class="logo-text">CareFuse</span>
+                    </a>
+                </div>
+
+                <div class="nav-links">
+                    <a href="index.html" class="nav-link">Home</a>
+                    <a href="problem.html" class="nav-link">Problem</a>
+                    <a href="solution.html" class="nav-link">Solution</a>
+                    <a href="evidence.html" class="nav-link">Evidence</a>
+                    <a href="application.html" class="nav-link">Application</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <div class="dropdown-menu">
+                            <a href="platform.html" class="dropdown-item">Platform</a>
+                            <a href="compliance.html" class="dropdown-item">Compliance</a>
+                            <a href="impact.html" class="dropdown-item">Impact</a>
+                        </div>
+                    </div>
+
+                    <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger active">Company</a>
+                        <div class="dropdown-menu">
+                            <a href="careers.html" class="dropdown-item">Careers</a>
+                            <a href="contact.html" class="dropdown-item">Contact</a>
+                            <a href="references.html" class="dropdown-item active">References</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="nav-actions">
+                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                        <i class="fas fa-bars"></i>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <section id="references" class="references-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Scientific References</span>
+                    <h2 class="section-title">Clinical &amp; Regulatory Citations</h2>
+                    <p class="section-description">Key publications, regulatory guidance, and technical documentation underpinning the CareFuse platform and application stories.</p>
+                </div>
+
+                <div class="references-grid">
+                    <div class="reference-item" id="ref1">
+                        <div class="ref-number">1</div>
+                        <div class="ref-content">
+                            <p>HL7 Da Vinci PAS Implementation Guide.</p>
+                            <a href="https://build.fhir.org/ig/HL7/davinci-pas/specification.html" class="ref-link" target="_blank" rel="noopener">Da Vinci PAS (FHIR IG)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref2">
+                        <div class="ref-number">2</div>
+                        <div class="ref-content">
+                            <p>Harvard Health Publishing. How long will my hip or knee replacement last?</p>
+                            <a href="https://www.health.harvard.edu/blog/how-long-will-my-hip-or-knee-replacement-last-2018071914272" class="ref-link" target="_blank" rel="noopener">Harvard Health (2018)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref3">
+                        <div class="ref-number">3</div>
+                        <div class="ref-content">
+                            <p>Renub Research. Knee replacement market analysis and forecast.</p>
+                            <a href="https://www.renub.com/knee-replacement-market-p.php" class="ref-link" target="_blank" rel="noopener">Renub Research</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref4">
+                        <div class="ref-number">4</div>
+                        <div class="ref-content">
+                            <p>ScienceDirect. Economic burden of knee and hip arthroplasty in younger patients.</p>
+                            <a href="https://www.sciencedirect.com/science/article/pii/S0883540325002529#:~:text=Over%20the%20last%20several%20decades,in%20younger%20patients%20%5B4%5D." class="ref-link" target="_blank" rel="noopener">ScienceDirect (2025)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref5">
+                        <div class="ref-number">5</div>
+                        <div class="ref-content">
+                            <p>ScienceDirect. Dissatisfaction rates following total knee arthroplasty.</p>
+                            <a href="https://www.sciencedirect.com/science/article/pii/S1877056817303298" class="ref-link" target="_blank" rel="noopener">ScienceDirect (2017)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref6">
+                        <div class="ref-number">6</div>
+                        <div class="ref-content">
+                            <p>Centers for Medicare &amp; Medicaid Services. THA/TKA patient-reported outcomes measure requirements.</p>
+                            <a href="https://qualitynet.cms.gov/inpatient/measures/tha-tka" class="ref-link" target="_blank" rel="noopener">CMS THA/TKA PRO-PM</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref7">
+                        <div class="ref-number">7</div>
+                        <div class="ref-content">
+                            <p>Evidence on variation and subjectivity in TKA decision-making.</p>
+                            <a href="https://bmchealthservres.biomedcentral.com/articles/10.1186/1472-6963-8-270" class="ref-link" target="_blank" rel="noopener">BMC Health Serv Res (2008)</a>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22688557/" class="ref-link" target="_blank" rel="noopener">Clin Orthop Relat Res (2013)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref8">
+                        <div class="ref-number">8</div>
+                        <div class="ref-content">
+                            <p>Cooley LLP. State artificial intelligence regulation tracker and analysis (2025).</p>
+                            <a href="https://www.cooley.com/news/insight/2024/2024-10-29-us-state-ai-legislation-tracker" class="ref-link" target="_blank" rel="noopener">Cooley State AI Regulation Analysis</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref9">
+                        <div class="ref-number">9</div>
+                        <div class="ref-content">
+                            <p>Structured conservative care effectiveness and payer budget impact modeling for knee osteoarthritis.</p>
+                            <a href="https://onlinelibrary.wiley.com/doi/10.1002/acr.24244" class="ref-link" target="_blank" rel="noopener">Arthritis Care &amp; Research</a>
+                            <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5673048/" class="ref-link" target="_blank" rel="noopener">Budget Impact Analysis</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref10">
+                        <div class="ref-number">10</div>
+                        <div class="ref-content">
+                            <p>Clement ND, et al. WOMAC MCID ≈ 10 at 12 months post-TKA.</p>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30179956/" class="ref-link" target="_blank" rel="noopener">PubMed (PMID 30179956)</a>
+                            <a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6259858/" class="ref-link" target="_blank" rel="noopener">PMC6259858</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref11">
+                        <div class="ref-number">11</div>
+                        <div class="ref-content">
+                            <p>Papakostidis C, Giannoudis PV, Watson JT, et al. Serious adverse events and 30-day readmission following elective TKA.</p>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33789702/" class="ref-link" target="_blank" rel="noopener">PubMed (PMID 33789702)</a>
+                            <a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC8011390/" class="ref-link" target="_blank" rel="noopener">PMC8011390</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref12">
+                        <div class="ref-number">12</div>
+                        <div class="ref-content">
+                            <p>CMS Interoperability &amp; Prior Authorization Final Rule (CMS-0057-F) fact sheet.</p>
+                            <a href="https://www.cms.gov/files/document/fact-sheet-cms-interoperability-and-prior-authorization-final-rule-cms-0057-f.pdf" class="ref-link" target="_blank" rel="noopener">CMS Fact Sheet (PDF)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref13">
+                        <div class="ref-number">13</div>
+                        <div class="ref-content">
+                            <p>NAIC Model Bulletin on Artificial Intelligence Systems.</p>
+                            <a href="https://content.naic.org/sites/default/files/cmte-h-big-data-artificial-intelligence-wg-ai-model-bulletin.pdf.pdf" class="ref-link" target="_blank" rel="noopener">NAIC AI Model Bulletin (PDF)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref14">
+                        <div class="ref-number">14</div>
+                        <div class="ref-content">
+                            <p>Medical Board of California. AB-3030 generative AI patient communication notice.</p>
+                            <a href="https://www.mbc.ca.gov/Resources/Medical-Resources/GenAI-Notification.aspx" class="ref-link" target="_blank" rel="noopener">Medical Board of California - GenAI Notification</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref15">
+                        <div class="ref-number">15</div>
+                        <div class="ref-content">
+                            <p>UpToDate. Total knee arthroplasty: Outcomes and indications.</p>
+                            <a href="https://www.uptodate.com/contents/total-knee-arthroplasty" class="ref-link" target="_blank" rel="noopener">UpToDate – TKA Outcomes</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref16">
+                        <div class="ref-number">16</div>
+                        <div class="ref-content">
+                            <p>Nature npj Digital Medicine. Identifying patients unlikely to benefit from total knee arthroplasty using ML.</p>
+                            <a href="https://www.nature.com/articles/s41746-024-01265-8" class="ref-link" target="_blank" rel="noopener">npj Digital Medicine (2024)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref17">
+                        <div class="ref-number">17</div>
+                        <div class="ref-content">
+                            <p>CMS. Advancing Interoperability and Improving Prior Authorization Processes Final Rule fact sheet.</p>
+                            <a href="https://www.cms.gov/newsroom/fact-sheets/advancing-interoperability-and-improving-prior-authorization-processes-final-rule-cms-0057-f" class="ref-link" target="_blank" rel="noopener">CMS Prior Authorization Final Rule (2024)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref18">
+                        <div class="ref-number">18</div>
+                        <div class="ref-content">
+                            <p>U.S. Department of Health &amp; Human Services. KOOS Jr. outcome measure guidance.</p>
+                            <a href="https://www.hhs.gov/guidance/sites/default/files/hhs-guidance-documents/koosjr.pdf" class="ref-link" target="_blank" rel="noopener">KOOS Jr. Guidance (PDF)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref19">
+                        <div class="ref-number">19</div>
+                        <div class="ref-content">
+                            <p>CMS Comprehensive Care for Joint Replacement (CJR) Model.</p>
+                            <a href="https://innovation.cms.gov/innovation-models/cjr" class="ref-link" target="_blank" rel="noopener">CMS CJR Model Overview</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref20">
+                        <div class="ref-number">20</div>
+                        <div class="ref-content">
+                            <p>Wilding JPH, et al. Once-weekly semaglutide in adults with overweight or obesity.</p>
+                            <a href="https://www.nejm.org/doi/full/10.1056/NEJMoa2032183" class="ref-link" target="_blank" rel="noopener">NEJM (2021)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref21">
+                        <div class="ref-number">21</div>
+                        <div class="ref-content">
+                            <p>Farr JN, et al. Effect of semaglutide on knee pain in obese adults with osteoarthritis.</p>
+                            <a href="https://jamanetwork.com/journals/jama/fullarticle/2801438" class="ref-link" target="_blank" rel="noopener">JAMA (2023)</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref22">
+                        <div class="ref-number">22</div>
+                        <div class="ref-content">
+                            <p>Lundberg SM, Lee SI. SHAP (SHapley Additive exPlanations) GitHub repository.</p>
+                            <a href="https://github.com/slundberg/shap" class="ref-link" target="_blank" rel="noopener">SHAP GitHub</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref23">
+                        <div class="ref-number">23</div>
+                        <div class="ref-content">
+                            <p>Vickers AJ, Elkin EB. Decision curve analysis: A novel method for evaluating prediction models.</p>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18833530/" class="ref-link" target="_blank" rel="noopener">Medical Decision Making (2008)</a>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+        <div class="next-section-nav">
+            <a href="index.html" class="btn btn-secondary">Next: Home</a>
+        </div>
+
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-content">
+                    <div class="footer-brand">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
+                        <span class="footer-brand-text">CareFuse</span>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Product</h4>
+                        <ul>
+                            <li><a href="solution.html">Solution</a></li>
+                            <li><a href="evidence.html">Evidence</a></li>
+                            <li><a href="platform.html">Platform</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Company</h4>
+                        <ul>
+                            <li><a href="careers.html">Careers</a></li>
+                            <li><a href="contact.html">Contact</a></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="footer-bottom">
+                    <div class="footer-legal">
+                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
+                    </div>
+
+                    <div class="footer-bottom-content">
+                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script src="js/main.js"></script>
+    <script src="js/calculator.js"></script>
+</body>
+</html>

--- a/roadmap.html
+++ b/roadmap.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CareFuse - Transparent AI for Hip & Knee Prior Authorization</title>
-    <meta name="description" content="Clinical-grade AI for payer UM teams. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.">
+    <title>CareFuse - Roadmap</title>
+    <meta name="description" content="See the CareFuse expansion roadmap spanning hip, knee, shoulder, and spine decision support.">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,7 +22,6 @@
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
 <body class="teal-theme">
-    <!-- Loading Screen -->
     <div id="loading-screen" class="loading-screen">
         <div class="loading-animation">
             <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
@@ -31,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Main Content -->
     <div id="main-content" class="main-content">
         <nav class="main-nav">
             <div class="nav-container">
@@ -43,7 +41,7 @@
                 </div>
 
                 <div class="nav-links">
-                    <a href="index.html" class="nav-link active">Home</a>
+                    <a href="index.html" class="nav-link">Home</a>
                     <a href="problem.html" class="nav-link">Problem</a>
                     <a href="solution.html" class="nav-link">Solution</a>
                     <a href="evidence.html" class="nav-link">Evidence</a>
@@ -58,7 +56,7 @@
                         </div>
                     </div>
 
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
+                    <a href="roadmap.html" class="nav-link active">Roadmap</a>
 
                     <div class="nav-dropdown">
                         <a href="#" class="nav-link dropdown-trigger">Company</a>
@@ -79,51 +77,56 @@
             </div>
         </nav>
 
-        <!-- Home / Hero Section -->
-        <section class="hero-section">
-            <div class="hero-container">
-                <div class="hero-content">
-                    <h1 class="hero-title">Transparent AI for Orthopedic Surgery Prediction</h1>
-                    <p class="hero-subtitle">CareFuse is the first company to build a counterfactual AI model for total knee arthroplasty (TKA), predicting individualized outcomes with and without surgery. With ~790k TKAs annually in the U.S., and 30% of patients gaining no benefit, our SHAP-explained platform empowers payers to identify the right moment for the right patient, reducing unnecessary surgeries and costs.</p>
+        <section class="roadmap-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">Strategic Vision</span>
+                    <h2 class="section-title">Expanding Clinical Decision Support</h2>
+                    <p class="section-description">CareFuse: comprehensive platform for evidence-based utilization management across orthopedic procedures.</p>
+                </div>
 
-                    <div class="hero-stats">
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-chart-line"></i>
-                            </div>
-                            <div class="stat-number">$9+ Billion</div>
-                            <div class="stat-label">spent in the US per year</div>
-                            <div class="stat-description">in knee replacement every year for the surgery alone (not including revisions or readmissions). <sup class="footnote"><a href="references.html#ref2">[2]</a></sup> This number is predicted to increase to $16.4 billion by 2032. <sup class="footnote"><a href="references.html#ref3">[3]</a></sup></div>
+                <div class="roadmap-timeline">
+                    <div class="timeline-item available">
+                        <div class="timeline-icon">
+                            <i class="fas fa-check-circle"></i>
                         </div>
-
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-procedures"></i>
-                            </div>
-                            <div class="stat-number">30%</div>
-                            <div class="stat-label">of Total Knee Replacements</div>
-                            <div class="stat-description">ultimately leave the patient dissatisfied <sup class="footnote"><a href="references.html#ref5">[5]</a></sup></div>
-                        </div>
-
-                        <div class="stat-card">
-                            <div class="stat-icon">
-                                <i class="fas fa-shield-alt"></i>
-                            </div>
-                            <div class="stat-number">93%</div>
-                            <div class="stat-label">Model AUC</div>
-                            <div class="stat-description">Clinical prediction accuracy for MCID achievement at 12 months</div>
+                        <div class="timeline-content">
+                            <h3>Hip &amp; Knee Arthroplasty</h3>
+                            <span class="timeline-status">Available Now</span>
+                            <p>Validated model with 93% AUC, preventing unnecessary procedures with transparent AI</p>
                         </div>
                     </div>
 
+                    <div class="timeline-item upcoming">
+                        <div class="timeline-icon">
+                            <i class="fas fa-clock"></i>
+                        </div>
+                        <div class="timeline-content">
+                            <h3>Shoulder Arthroplasty</h3>
+                            <span class="timeline-status">Q2 2025</span>
+                            <p>Expanding predictive technology to shoulder replacement procedures</p>
+                        </div>
+                    </div>
+
+                    <div class="timeline-item future">
+                        <div class="timeline-icon">
+                            <i class="fas fa-lightbulb"></i>
+                        </div>
+                        <div class="timeline-content">
+                            <h3>Spinal Fusion</h3>
+                            <span class="timeline-status">2026</span>
+                            <p>Intelligent prediction for spinal arthrodesis procedures</p>
+                        </div>
+                    </div>
                 </div>
+
             </div>
         </section>
 
         <div class="next-section-nav">
-            <a href="problem.html" class="btn btn-secondary">Next: Problem</a>
+            <a href="references.html" class="btn btn-secondary">Next: References</a>
         </div>
 
-        <!-- Footer -->
         <footer class="footer">
             <div class="footer-container">
                 <div class="footer-content">
@@ -163,31 +166,6 @@
         </footer>
     </div>
 
-    <!-- MCID Tooltip -->
-    <div id="mcid-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>MCID (Minimal Clinically Important Difference)</h4>
-            <p>The smallest change in a treatment outcome that a patient would identify as important. For WOMAC scores, ΔWOMAC ≥ 10 points represents meaningful clinical improvement.</p>
-        </div>
-    </div>
-
-    <!-- SHAP Tooltip -->
-    <div id="shap-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>SHAP (SHapley Additive exPlanations)</h4>
-            <p>A method to explain individual predictions by computing the contribution of each feature to the prediction. Provides transparent, interpretable AI explanations.</p>
-        </div>
-    </div>
-
-    <!-- PAS Tooltip -->
-    <div id="pas-tooltip" class="tooltip">
-        <div class="tooltip-content">
-            <h4>PAS (Prior Authorization Support)</h4>
-            <p>HL7 FHIR implementation guide for electronic prior authorization workflows, enabling seamless integration between providers and payers.</p>
-        </div>
-    </div>
-
-    <!-- Scripts -->
     <script src="js/main.js"></script>
     <script src="js/calculator.js"></script>
 </body>

--- a/solution.html
+++ b/solution.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CareFuse - Solution & Application</title>
+    <meta name="description" content="See how CareFuse delivers counterfactual AI predictions, SHAP transparency, and workflow-ready decision support for total knee arthroplasty.">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <!-- Icons -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="css/main-styles.css" rel="stylesheet">
+    <link href="css/components.css" rel="stylesheet">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="images/carefuse-logo.png">
+</head>
+<body class="teal-theme">
+    <div id="loading-screen" class="loading-screen">
+        <div class="loading-animation">
+            <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
+            <div class="loading-text">CareFuse</div>
+            <div class="loading-subtitle">Loading clinical platform...</div>
+        </div>
+    </div>
+
+    <div id="main-content" class="main-content">
+        <nav class="main-nav">
+            <div class="nav-container">
+                <div class="nav-logo">
+                    <a href="index.html" class="nav-logo-link">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
+                        <span class="logo-text">CareFuse</span>
+                    </a>
+                </div>
+
+                <div class="nav-links">
+                    <a href="index.html" class="nav-link">Home</a>
+                    <a href="problem.html" class="nav-link">Problem</a>
+                    <a href="solution.html" class="nav-link active">Solution</a>
+                    <a href="evidence.html" class="nav-link">Evidence</a>
+                    <a href="application.html" class="nav-link">Application</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                        <div class="dropdown-menu">
+                            <a href="platform.html" class="dropdown-item">Platform</a>
+                            <a href="compliance.html" class="dropdown-item">Compliance</a>
+                            <a href="impact.html" class="dropdown-item">Impact</a>
+                        </div>
+                    </div>
+
+                    <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                    <div class="nav-dropdown">
+                        <a href="#" class="nav-link dropdown-trigger">Company</a>
+                        <div class="dropdown-menu">
+                            <a href="careers.html" class="dropdown-item">Careers</a>
+                            <a href="contact.html" class="dropdown-item">Contact</a>
+                            <a href="references.html" class="dropdown-item">References</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="nav-actions">
+                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                        <i class="fas fa-bars"></i>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <section id="solution" class="solution-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">CareFuse Solution</span>
+                    <h2 class="section-title">Clinical Decision Support</h2>
+                    <p class="section-description">Predict whether a member will achieve MCID (ΔWOMAC ≥ 10) at 12 months with transparent, explainable AI built for UM workflows.<sup class="footnote"><a href="references.html#ref10">[10]</a></sup></p>
+                </div>
+
+                <div class="solution-content">
+                    <div class="case-study-card">
+                        <div class="case-header">
+                            <h3>Patient Profile</h3>
+                        </div>
+
+                        <div class="case-body">
+                            <div class="patient-profile-table">
+                                <table class="profile-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Feature</th>
+                                            <th>Value</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Age</td>
+                                            <td>74</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Sex</td>
+                                            <td>F</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Body Mass Index (BMI)</td>
+                                            <td>Obese</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Pain &amp; Function</td>
+                                            <td>15.6</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Pain</td>
+                                            <td>4.0</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Stiffness</td>
+                                            <td>1.0</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Disability</td>
+                                            <td>10.6</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Lifestyle Modification</td>
+                                            <td>None</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <p class="patient-disclaimer">CareFuse is an FDA-exempt decision assistance tool that supports providers with data-driven insights. It is not intended to deny care but to assist clinicians in making informed decisions.</p>
+
+                            <div class="tka-explanation">
+                                <h4>About TKA Surgery</h4>
+                                <p><strong>Total knee arthroplasty (TKA) is an invasive surgery with risks and a lengthy recovery period. This software helps identify potentially ineffective surgeries before they occur to protect patient well-being.</strong><sup class="footnote"><a href="references.html#ref11">[11]</a></sup></p>
+                            </div>
+
+                            <div class="prediction-sections">
+                                <div class="prediction-section tka-section">
+                                    <div class="section-header-with-prediction">
+                                        <h4>TKA Success</h4>
+                                        <div class="prediction-result-box low-benefit-red">
+                                            Prediction: Low Benefit Likelihood
+                                        </div>
+                                    </div>
+                                    <div class="prediction-details">
+                                        <div class="prediction-probability">
+                                            <strong>Predicted Probability:</strong> 21%
+                                        </div>
+                                        <div class="probability-bar">
+                                            <div class="probability-fill tka" style="width: 21%"></div>
+                                        </div>
+                                        <div class="prediction-status danger">
+                                            Surgery benefit is unlikely
+                                        </div>
+                                        <div class="prediction-summary">
+                                            <strong>Summary:</strong> The model estimates a 21% chance of success, with a cutoff of 37%. Your prediction is driven up by Body Mass Index, but somewhat offset by Baseline Disability, Baseline Stiffness, Baseline Pain &amp; Function. Recommend initiating intensive conservative care to mitigate factors that worsen knee osteoarthritis before revisiting surgical authorization. Support a 10% weight loss prior to surgical reconsideration.
+                                        </div>
+
+                                        <div class="top-influencers">
+                                            <h5>Top Influencers</h5>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Disability</span>
+                                                <span class="influencer-value negative">18%</span>
+                                                <span class="influencer-impact">hurts</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Stiffness</span>
+                                                <span class="influencer-value negative">18%</span>
+                                                <span class="influencer-impact">hurts</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Pain &amp; Function</span>
+                                                <span class="influencer-value negative">15%</span>
+                                                <span class="influencer-impact">hurts</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Body Mass Index (BMI)</span>
+                                                <span class="influencer-value positive">6%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="prediction-section conservative-section">
+                                    <div class="section-header-simple">
+                                        <h4>Conservative Success</h4>
+                                    </div>
+                                    <div class="prediction-details">
+                                        <div class="prediction-probability">
+                                            <strong>Predicted Probability:</strong> 60%
+                                        </div>
+                                        <div class="probability-bar">
+                                            <div class="probability-fill conservative" style="width: 60%"></div>
+                                        </div>
+                                        <div class="prediction-status success">
+                                            Conservative care benefit is likely
+                                        </div>
+                                        <div class="prediction-summary">
+                                            <strong>Summary:</strong> The model estimates a 60% chance of success, with a cutoff of 50%. Your prediction is driven up by Baseline Pain, Baseline Pain &amp; Function, but somewhat offset by Lifestyle Modification. Recommend continuing conservative care practices such as weight loss and physical therapy to sustain improvement.
+                                        </div>
+
+                                        <div class="top-influencers">
+                                            <h5>Top Influencers</h5>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Pain</span>
+                                                <span class="influencer-value positive">23%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Pain &amp; Function</span>
+                                                <span class="influencer-value positive">18%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Disability</span>
+                                                <span class="influencer-value positive">16%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Stiffness</span>
+                                                <span class="influencer-value positive">12%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="counterfactual-explanation">
+                                <h4>Counterfactual Analysis</h4>
+                                <p><strong>Propensity Score Weighting:</strong> Our model generates counterfactual predictions for conservative care using propensity-score weighting, allowing direct comparison between surgical and non-surgical treatment outcomes for informed decision-making.</p>
+                            </div>
+
+                            <div class="case-actions">
+                                <div class="btn btn-primary button-placeholder">Download PDF</div>
+                                <div class="btn btn-secondary button-placeholder">Back</div>
+                            </div>
+
+                            <div class="contributing-factors">
+                                <p><strong>Main contributing factors</strong> List of features that most influence the predicted outcome.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="solution-features">
+                        <div class="feature-card">
+                            <div class="feature-icon">
+                                <i class="fas fa-user-md"></i>
+                            </div>
+                            <h3>Decision Support</h3>
+                            <p>Not auto-denial—configurable thresholds aligned with plan policy. Human-in-the-loop review required for all decisions.</p>
+                        </div>
+
+                        <div class="feature-card">
+                            <div class="feature-icon">
+                                <i class="fas fa-cogs"></i>
+                            </div>
+                            <h3>Workflow Integration</h3>
+                            <p>Built for InterQual/MCG workflows with HL7 FHIR PAS compatibility. Seamless integration with existing UM systems.</p>
+                        </div>
+
+                        <div class="feature-card">
+                            <div class="feature-icon">
+                                <i class="fas fa-file-medical"></i>
+                            </div>
+                            <h3>Complete Documentation</h3>
+                            <p>Predicted probability, risk narrative, literature snippets, and exportable FHIR bundles for comprehensive documentation.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="next-section-nav">
+            <a href="evidence.html" class="btn btn-secondary">Next: Evidence</a>
+        </div>
+
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-content">
+                    <div class="footer-brand">
+                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
+                        <span class="footer-brand-text">CareFuse</span>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Product</h4>
+                        <ul>
+                            <li><a href="solution.html">Solution</a></li>
+                            <li><a href="evidence.html">Evidence</a></li>
+                            <li><a href="platform.html">Platform</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer-section">
+                        <h4>Company</h4>
+                        <ul>
+                            <li><a href="careers.html">Careers</a></li>
+                            <li><a href="contact.html">Contact</a></li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="footer-bottom">
+                    <div class="footer-legal">
+                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
+                    </div>
+
+                    <div class="footer-bottom-content">
+                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script src="js/main.js"></script>
+    <script src="js/calculator.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Application page and link it between Evidence and Platform while removing the obsolete CTA page
- reorganize the navigation so Implementation (Platform, Compliance, Impact) is grouped and References live inside the Company menu
- relocate the Next buttons for consistent bottom placement with extra spacing and clean the footers by dropping legacy policy links

## Testing
- not run (static site changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e570b556bc8321ae2d52773e7d235f