### PR TITLE
Refactor shared layout and expand home content

### DIFF
--- a/application.html
+++ b/application.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link active">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="application" class="application-section">
             <div class="section-container">
@@ -155,45 +111,10 @@
             <a href="platform.html" class="btn btn-secondary">Next: Platform</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>
+    <script src="js/calculator.js"></script>
 </body>
 </html>

--- a/call-to-action.html
+++ b/call-to-action.html
@@ -31,44 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="platform.html" class="nav-link">Platform</a>
-                    <a href="compliance.html" class="nav-link">Compliance</a>
-                    <a href="impact.html" class="nav-link">Impact</a>
-                    <a href="call-to-action.html" class="nav-link active">CTA</a>
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-                    <a href="references.html" class="nav-link">References</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section class="cta-section">
             <div class="section-container">
@@ -136,48 +99,7 @@
             </div>
         </section>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                        <div class="footer-bottom-links">
-                            <a href="#privacy">Privacy Policy</a>
-                            <a href="#terms">Terms of Service</a>
-                            <a href="#hipaa">HIPAA Compliance</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/careers.html
+++ b/careers.html
@@ -9,56 +9,20 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
-<body>
-    <nav class="main-nav">
-        <div class="nav-container">
-            <div class="nav-logo">
-                <a href="index.html" class="nav-logo-link">
-                    <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                    <span class="logo-text">CareFuse</span>
-                </a>
-            </div>
-            
-            <div class="nav-links">
-                <a href="index.html" class="nav-link">Home</a>
-                <a href="problem.html" class="nav-link">Problem</a>
-                <a href="solution.html" class="nav-link">Solution</a>
-                <a href="evidence.html" class="nav-link">Evidence</a>
-                <a href="application.html" class="nav-link">Application</a>
-
-                <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                    <div class="dropdown-menu">
-                        <a href="platform.html" class="dropdown-item">Platform</a>
-                        <a href="compliance.html" class="dropdown-item">Compliance</a>
-                        <a href="impact.html" class="dropdown-item">Impact</a>
-                    </div>
-                </div>
-
-                <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger active">Company</a>
-                    <div class="dropdown-menu">
-                        <a href="careers.html" class="dropdown-item active">Careers</a>
-                        <a href="contact.html" class="dropdown-item">Contact</a>
-                        <a href="references.html" class="dropdown-item">References</a>
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="nav-actions">
-                <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                    <i class="fas fa-bars"></i>
-                </button>
-            </div>
+<body class="teal-theme">
+    <div id="loading-screen" class="loading-screen">
+        <div class="loading-animation">
+            <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
+            <div class="loading-text">CareFuse</div>
+            <div class="loading-subtitle">Loading clinical platform...</div>
         </div>
-    </nav>
+    </div>
 
-    <main class="careers-page">
-        <section class="page-hero">
+    <div id="main-content" class="main-content">
+        <div id="navigation-placeholder"></div>
+
+        <main class="careers-page">
+            <section class="page-hero">
             <div class="section-container">
                 <div class="page-header">
                     <h1 class="page-title">Careers at CareFuse</h1>
@@ -153,40 +117,13 @@
                 </div>
             </div>
         </section>
-    </main>
+        </main>
 
-    <footer class="main-footer">
-        <div class="footer-container">
-            <div class="footer-content">
-                <div class="footer-section">
-                    <div class="footer-logo">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo-image">
-                        <span class="footer-logo-text">CareFuse</span>
-                    </div>
-                    <p class="footer-description">Transparent AI for evidence-based prior authorization in orthopedic care.</p>
-                </div>
-                
-                <div class="footer-section">
-                    <h4>Company</h4>
-                    <ul class="footer-links">
-                        <li><a href="careers.html">Careers</a></li>
-                        <li><a href="contact.html">Contact</a></li>
-                    </ul>
-                </div>
-                
-                <div class="footer-section">
-                    <h4>Contact</h4>
-                    <p>yuri.braga@carefuseai.com</p>
-                </div>
-            </div>
-            
-            <div class="footer-bottom">
-                <p>&copy; 2025 CareFuse. All rights reserved.</p>
-            </div>
-        </div>
-    </footer>
+        <div id="footer-placeholder"></div>
+    </div>
 
     <script src="js/main.js"></script>
+    <script src="js/calculator.js"></script>
 </body>
 </html>
 

--- a/compliance.html
+++ b/compliance.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger active">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item active">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section class="compliance-section">
             <div class="section-container">
@@ -158,43 +114,7 @@
             <a href="impact.html" class="btn btn-secondary">Next: Impact</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -9,57 +9,21 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="icon" type="image/png" href="images/carefuse-logo.png">
 </head>
-<body>
-    <nav class="main-nav">
-        <div class="nav-container">
-            <div class="nav-logo">
-                <a href="index.html" class="nav-logo-link">
-                    <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                    <span class="logo-text">CareFuse</span>
-                </a>
-            </div>
-            
-            <div class="nav-links">
-                <a href="index.html" class="nav-link">Home</a>
-                <a href="problem.html" class="nav-link">Problem</a>
-                <a href="solution.html" class="nav-link">Solution</a>
-                <a href="evidence.html" class="nav-link">Evidence</a>
-                <a href="application.html" class="nav-link">Application</a>
-
-                <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                    <div class="dropdown-menu">
-                        <a href="platform.html" class="dropdown-item">Platform</a>
-                        <a href="compliance.html" class="dropdown-item">Compliance</a>
-                        <a href="impact.html" class="dropdown-item">Impact</a>
-                    </div>
-                </div>
-
-                <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                <div class="nav-dropdown">
-                    <a href="#" class="nav-link dropdown-trigger active">Company</a>
-                    <div class="dropdown-menu">
-                        <a href="careers.html" class="dropdown-item">Careers</a>
-                        <a href="contact.html" class="dropdown-item active">Contact</a>
-                        <a href="references.html" class="dropdown-item">References</a>
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="nav-actions">
-                <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                    <i class="fas fa-bars"></i>
-                </button>
-            </div>
+<body class="teal-theme">
+    <div id="loading-screen" class="loading-screen">
+        <div class="loading-animation">
+            <img src="images/carefuse-logo.png" alt="CareFuse logo" class="loading-logo">
+            <div class="loading-text">CareFuse</div>
+            <div class="loading-subtitle">Loading clinical platform...</div>
         </div>
-    </nav>
+    </div>
 
-    <main class="contact-page">
-        <section class="page-hero">
-            <div class="section-container">
+    <div id="main-content" class="main-content">
+        <div id="navigation-placeholder"></div>
+
+        <main class="contact-page">
+            <section class="page-hero">
+                <div class="section-container">
                 <div class="page-header">
                     <h1 class="page-title">Contact CareFuse</h1>
                     <p class="page-subtitle">We want to hear about your challenges and find out how we can help you improve prior authorization outcomes</p>
@@ -67,8 +31,8 @@
             </div>
         </section>
 
-        <section class="contact-content">
-            <div class="section-container">
+            <section class="contact-content">
+                <div class="section-container">
                 <div class="contact-grid">
                     <div class="contact-info">
                         <h2>Let's Discuss Your Needs</h2>
@@ -210,41 +174,14 @@
                     </div>
                 </div>
             </div>
-        </section>
-    </main>
+            </section>
+        </main>
 
-    <footer class="main-footer">
-        <div class="footer-container">
-            <div class="footer-content">
-                <div class="footer-section">
-                    <div class="footer-logo">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo-image">
-                        <span class="footer-logo-text">CareFuse</span>
-                    </div>
-                    <p class="footer-description">Transparent AI for evidence-based prior authorization in orthopedic care.</p>
-                </div>
-                
-                <div class="footer-section">
-                    <h4>Company</h4>
-                    <ul class="footer-links">
-                        <li><a href="careers.html">Careers</a></li>
-                        <li><a href="contact.html">Contact</a></li>
-                    </ul>
-                </div>
-                
-                <div class="footer-section">
-                    <h4>Contact</h4>
-                    <p>yuri.braga@carefuseai.com</p>
-                </div>
-            </div>
-            
-            <div class="footer-bottom">
-                <p>&copy; 2025 CareFuse. All rights reserved.</p>
-            </div>
-        </div>
-    </footer>
+        <div id="footer-placeholder"></div>
+    </div>
 
     <script src="js/main.js"></script>
+    <script src="js/calculator.js"></script>
     <script>
         (function() {
             const form = document.getElementById('carefuse-contact-form');

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -254,17 +254,19 @@ body {
 .btn {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.5rem;
     padding: 0.75rem 1.5rem;
     border: none;
     border-radius: var(--radius-lg);
     font-family: var(--font-family-primary);
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: 1.3125rem;
     text-decoration: none;
     cursor: pointer;
     transition: var(--transition-fast);
     white-space: nowrap;
+    text-align: center;
 }
 
 .btn-primary {
@@ -301,7 +303,7 @@ body {
 
 .btn-large {
     padding: 1rem 2rem;
-    font-size: 1rem;
+    font-size: 1.5rem;
 }
 
 .next-section-nav {
@@ -1918,10 +1920,12 @@ body {
 
 .footer-bottom-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
+    flex-direction: column;
     flex-wrap: wrap;
     gap: 1rem;
+    text-align: center;
 }
 
 .footer-bottom-content p {
@@ -1931,6 +1935,8 @@ body {
 
 .footer-bottom-links {
     display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
     gap: 2rem;
 }
 

--- a/evidence.html
+++ b/evidence.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link active">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="evidence" class="evidence-section">
             <div class="section-container">
@@ -142,43 +98,7 @@
             <a href="application.html" class="btn btn-secondary">Next: Application</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/impact.html
+++ b/impact.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger active">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item active">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="impact" class="impact-section">
             <div class="section-container">
@@ -152,43 +108,7 @@
             <a href="roadmap.html" class="btn btn-secondary">Next: Roadmap</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -33,51 +33,7 @@
 
     <!-- Main Content -->
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link active">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <!-- Home / Hero Section -->
         <section class="hero-section">
@@ -119,48 +75,280 @@
             </div>
         </section>
 
+
+        <section id="solution" class="solution-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <span class="section-badge">CareFuse Solution</span>
+                    <h2 class="section-title">Clinical Decision Support</h2>
+                    <p class="section-description">Predict whether a member will achieve MCID (ΔWOMAC ≥ 10) at 12 months with transparent, explainable AI built for UM workflows.<sup class="footnote"><a href="references.html#ref10">[10]</a></sup></p>
+                </div>
+
+                <div class="solution-content">
+                    <div class="case-study-card">
+                        <div class="case-header">
+                            <h3>Patient Profile</h3>
+                        </div>
+
+                        <div class="case-body">
+                            <div class="patient-profile-table">
+                                <table class="profile-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Feature</th>
+                                            <th>Value</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Age</td>
+                                            <td>74</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Sex</td>
+                                            <td>F</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Body Mass Index (BMI)</td>
+                                            <td>Obese</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Pain &amp; Function</td>
+                                            <td>15.6</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Pain</td>
+                                            <td>4.0</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Stiffness</td>
+                                            <td>1.0</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Baseline Disability</td>
+                                            <td>10.6</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Lifestyle Modification</td>
+                                            <td>None</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <p class="patient-disclaimer">CareFuse is an FDA-exempt decision assistance tool that supports providers with data-driven insights. It is not intended to deny care but to assist clinicians in making informed decisions.</p>
+
+                            <div class="tka-explanation">
+                                <h4>About TKA Surgery</h4>
+                                <p><strong>Total knee arthroplasty (TKA) is an invasive surgery with risks and a lengthy recovery period. This software helps identify potentially ineffective surgeries before they occur to protect patient well-being.</strong><sup class="footnote"><a href="references.html#ref11">[11]</a></sup></p>
+                            </div>
+
+                            <div class="prediction-sections">
+                                <div class="prediction-section tka-section">
+                                    <div class="section-header-with-prediction">
+                                        <h4>TKA Success</h4>
+                                        <div class="prediction-result-box low-benefit-red">
+                                            Prediction: Low Benefit Likelihood
+                                        </div>
+                                    </div>
+                                    <div class="prediction-details">
+                                        <div class="prediction-probability">
+                                            <strong>Predicted Probability:</strong> 21%
+                                        </div>
+                                        <div class="probability-bar">
+                                            <div class="probability-fill tka" style="width: 21%"></div>
+                                        </div>
+                                        <div class="prediction-status danger">
+                                            Surgery benefit is unlikely
+                                        </div>
+                                        <div class="prediction-summary">
+                                            <strong>Summary:</strong> The model estimates a 21% chance of success, with a cutoff of 37%. Your prediction is driven up by Body Mass Index, but somewhat offset by Baseline Disability, Baseline Stiffness, Baseline Pain &amp; Function. Recommend initiating intensive conservative care to mitigate factors that worsen knee osteoarthritis before revisiting surgical authorization. Support a 10% weight loss prior to surgical reconsideration.
+                                        </div>
+
+                                        <div class="top-influencers">
+                                            <h5>Top Influencers</h5>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Disability</span>
+                                                <span class="influencer-value negative">18%</span>
+                                                <span class="influencer-impact">hurts</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Stiffness</span>
+                                                <span class="influencer-value negative">18%</span>
+                                                <span class="influencer-impact">hurts</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Pain &amp; Function</span>
+                                                <span class="influencer-value negative">15%</span>
+                                                <span class="influencer-impact">hurts</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Body Mass Index (BMI)</span>
+                                                <span class="influencer-value positive">6%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="prediction-section conservative-section">
+                                    <div class="section-header-simple">
+                                        <h4>Conservative Success</h4>
+                                    </div>
+                                    <div class="prediction-details">
+                                        <div class="prediction-probability">
+                                            <strong>Predicted Probability:</strong> 60%
+                                        </div>
+                                        <div class="probability-bar">
+                                            <div class="probability-fill conservative" style="width: 60%"></div>
+                                        </div>
+                                        <div class="prediction-status success">
+                                            Conservative care benefit is likely
+                                        </div>
+                                        <div class="prediction-summary">
+                                            <strong>Summary:</strong> The model estimates a 60% chance of success, with a cutoff of 50%. Your prediction is driven up by Baseline Pain, Baseline Pain &amp; Function, but somewhat offset by Lifestyle Modification. Recommend continuing conservative care practices such as weight loss and physical therapy to sustain improvement.
+                                        </div>
+
+                                        <div class="top-influencers">
+                                            <h5>Top Influencers</h5>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Pain</span>
+                                                <span class="influencer-value positive">23%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Pain &amp; Function</span>
+                                                <span class="influencer-value positive">18%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Disability</span>
+                                                <span class="influencer-value positive">16%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                            <div class="influencer-item">
+                                                <span class="influencer-name">Baseline Stiffness</span>
+                                                <span class="influencer-value positive">12%</span>
+                                                <span class="influencer-impact">helps</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="counterfactual-explanation">
+                                <h4>Counterfactual Analysis</h4>
+                                <p><strong>Propensity Score Weighting:</strong> Our model generates counterfactual predictions for conservative care using propensity-score weighting, allowing direct comparison between surgical and non-surgical treatment outcomes for informed decision-making.</p>
+                            </div>
+
+                            <div class="case-actions">
+                                <div class="btn btn-primary button-placeholder">Download PDF</div>
+                                <div class="btn btn-secondary button-placeholder">Back</div>
+                            </div>
+
+                            <div class="contributing-factors">
+                                <p><strong>Main contributing factors</strong> List of features that most influence the predicted outcome.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="solution-features">
+                        <div class="feature-card">
+                            <div class="feature-icon">
+                                <i class="fas fa-user-md"></i>
+                            </div>
+                            <h3>Decision Support</h3>
+                            <p>Not auto-denial—configurable thresholds aligned with plan policy. Human-in-the-loop review required for all decisions.</p>
+                        </div>
+
+                        <div class="feature-card">
+                            <div class="feature-icon">
+                                <i class="fas fa-cogs"></i>
+                            </div>
+                            <h3>Workflow Integration</h3>
+                            <p>Built for InterQual/MCG workflows with HL7 FHIR PAS compatibility. Seamless integration with existing UM systems.</p>
+                        </div>
+
+                        <div class="feature-card">
+                            <div class="feature-icon">
+                                <i class="fas fa-file-medical"></i>
+                            </div>
+                            <h3>Complete Documentation</h3>
+                            <p>Predicted probability, risk narrative, literature snippets, and exportable FHIR bundles for comprehensive documentation.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+
+        <section id="evidence" class="evidence-section">
+            <div class="section-container">
+                <div class="section-header">
+                    <div class="section-badge">Clinical Evidence</div>
+                    <h2 class="section-title">Validation &amp; Performance</h2>
+                    <p class="section-description">At CareFuse, we've built a calibrated, explainable logistic-regression model (OAI: demographics + WOMAC) that estimates a TKA patient's probability of achieving MCID and generates a counterfactual for conservative care using propensity-score weighting. Across 50 multi-seed holdout splits it achieves AUC ≈ 0.93, with transparent calibration/thresholding and SHAP explanations suited for clinical review.</p>
+                </div>
+
+                <div class="data-inputs-callout">
+                    <div class="callout-card">
+                        <div class="callout-icon">
+                            <i class="fas fa-clipboard-list"></i>
+                        </div>
+                        <div class="callout-content">
+                            <h3>How we generate a prediction</h3>
+                            <p>This tool can generate a personalized prediction using information the patient can readily provide (basic demographics and medical history) together with responses to an internationally validated arthritis questionnaire <span class="info-tooltip" data-tooltip="Refers to widely used instruments in osteoarthritis research and clinical practice"><i class="fas fa-info-circle"></i></span>. No imaging or specialized tests are required for the demo.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="validation-highlights">
+                    <h3>Validation Highlights</h3>
+                    <div class="headline-metrics">
+                        <div class="metric-card">
+                            <div class="metric-number">Up to 97%</div>
+                            <div class="metric-label">Accuracy</div>
+                        </div>
+
+                        <div class="metric-card">
+                            <div class="metric-number">AUC 0.93</div>
+                            <div class="metric-label">TKA pathway</div>
+                        </div>
+
+                        <div class="metric-card">
+                            <div class="metric-number">AUC 0.87</div>
+                            <div class="metric-label">Conservative pathway</div>
+                        </div>
+
+                        <div class="metric-card">
+                            <div class="metric-number">Sensitivity</div>
+                            <div class="metric-label">to non-MCID procedures</div>
+                        </div>
+                    </div>
+
+                    <div class="validation-footnote">
+                        <p>Internal validation. Performance depends on thresholds and population. For demonstration only; not a coverage determination.</p>
+                        <a href="#methods" class="see-methods-link">See methods</a>
+                    </div>
+                </div>
+
+                <div id="methods" class="methods-section">
+                    <h3>Methods</h3>
+                    <div class="methods-content">
+                        <p>Our model uses logistic regression with demographics and WOMAC scores from the OAI dataset. We completed a live pilot with Hapvida (15.7M policyholders) to demonstrate feasibility and workflow integration. In the U.S., our pilot would train a new model on your de-identified data using the same pipeline and deploy a secure, metered API with audit logging.</p>
+                        <p>CareFuse is represented by Gunderson Dettmer, and our product is built under the FDA non-device CDS exemption.</p>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
         <div class="next-section-nav">
             <a href="problem.html" class="btn btn-secondary">Next: Problem</a>
         </div>
 
-        <!-- Footer -->
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <!-- Shared Footer -->
+        <div id="footer-placeholder"></div>
     </div>
 
     <!-- MCID Tooltip -->

--- a/js/main.js
+++ b/js/main.js
@@ -4,8 +4,116 @@
 let isLoading = true;
 let currentSection = 'hero';
 
+// Shared layout templates
+const NAVIGATION_TEMPLATE = `
+    <nav class="main-nav">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <a href="index.html" class="nav-logo-link">
+                    <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
+                    <span class="logo-text">CareFuse</span>
+                </a>
+            </div>
+
+            <div class="nav-links">
+                <a href="index.html" class="nav-link">Home</a>
+                <a href="problem.html" class="nav-link">Problem</a>
+                <a href="application.html" class="nav-link">Application</a>
+
+                <div class="nav-dropdown">
+                    <a href="#" class="nav-link dropdown-trigger">Implementation</a>
+                    <div class="dropdown-menu">
+                        <a href="platform.html" class="dropdown-item">Platform</a>
+                        <a href="compliance.html" class="dropdown-item">Compliance</a>
+                        <a href="impact.html" class="dropdown-item">Impact</a>
+                    </div>
+                </div>
+
+                <a href="roadmap.html" class="nav-link">Roadmap</a>
+
+                <div class="nav-dropdown">
+                    <a href="#" class="nav-link dropdown-trigger">Company</a>
+                    <div class="dropdown-menu">
+                        <a href="careers.html" class="dropdown-item">Careers</a>
+                        <a href="contact.html" class="dropdown-item">Contact</a>
+                        <a href="references.html" class="dropdown-item">References</a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="nav-actions">
+                <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
+                <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
+                    <i class="fas fa-bars"></i>
+                </button>
+            </div>
+        </div>
+    </nav>
+`;
+
+const FOOTER_TEMPLATE = `
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-content">
+                <div class="footer-brand">
+                    <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
+                    <span class="footer-brand-text">CareFuse</span>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Product</h4>
+                    <ul>
+                        <li><a href="index.html#solution">Solution</a></li>
+                        <li><a href="index.html#evidence">Evidence</a></li>
+                        <li><a href="platform.html">Platform</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Company</h4>
+                    <ul>
+                        <li><a href="careers.html">Careers</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="footer-bottom">
+                <div class="footer-legal">
+                    <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
+                </div>
+
+                <div class="footer-bottom-content">
+                    <p>&copy; 2025 CareFuse. All rights reserved.</p>
+                    <div class="footer-bottom-links">
+                        <a href="#privacy">Privacy Policy</a>
+                        <a href="#terms">Terms of Service</a>
+                        <a href="#hipaa">HIPAA Compliance</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+`;
+
+// Inject shared layout components
+function injectSharedLayout() {
+    const navPlaceholder = document.getElementById('navigation-placeholder');
+    if (navPlaceholder && !navPlaceholder.dataset.rendered) {
+        navPlaceholder.innerHTML = NAVIGATION_TEMPLATE;
+        navPlaceholder.dataset.rendered = 'true';
+    }
+
+    const footerPlaceholder = document.getElementById('footer-placeholder');
+    if (footerPlaceholder && !footerPlaceholder.dataset.rendered) {
+        footerPlaceholder.innerHTML = FOOTER_TEMPLATE;
+        footerPlaceholder.dataset.rendered = 'true';
+    }
+}
+
 // DOM Content Loaded
 document.addEventListener('DOMContentLoaded', function() {
+    injectSharedLayout();
     initializeWebsite();
 });
 
@@ -14,7 +122,7 @@ function initializeWebsite() {
     // Hide loading screen after content loads
     setTimeout(() => {
         hideLoadingScreen();
-    }, 2000);
+    }, 1000);
     
     // Initialize components
     initializeNavigation();
@@ -53,6 +161,29 @@ function hideLoadingScreen() {
 function initializeNavigation() {
     const navbar = document.querySelector('.main-nav') || document.querySelector('.navbar');
     const navLinks = document.querySelectorAll('.nav-links a');
+
+    if (navLinks.length) {
+        const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+        navLinks.forEach(link => {
+            const href = link.getAttribute('href');
+            if (!href) {
+                return;
+            }
+
+            const normalizedHref = href.split('#')[0] || 'index.html';
+            if (normalizedHref === currentPath || (normalizedHref === 'index.html' && currentPath === '')) {
+                link.classList.add('active');
+
+                const parentDropdown = link.closest('.nav-dropdown');
+                if (parentDropdown) {
+                    const trigger = parentDropdown.querySelector('.dropdown-trigger');
+                    if (trigger) {
+                        trigger.classList.add('active');
+                    }
+                }
+            }
+        });
+    }
 
     if (navbar) {
         // Navbar scroll effect

--- a/platform.html
+++ b/platform.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger active">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item active">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="platform" class="platform-section">
             <div class="section-container">
@@ -177,43 +133,7 @@
             <a href="compliance.html" class="btn btn-secondary">Next: Compliance</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/problem.html
+++ b/problem.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link active">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="problem" class="problem-section">
             <div class="section-container">
@@ -194,43 +150,7 @@
             <a href="solution.html" class="btn btn-secondary">Next: Solution</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/references.html
+++ b/references.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger active">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item active">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="references" class="references-section">
             <div class="section-container">
@@ -282,43 +238,7 @@
             <a href="index.html" class="btn btn-secondary">Next: Home</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/roadmap.html
+++ b/roadmap.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link active">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section class="roadmap-section">
             <div class="section-container">
@@ -127,43 +83,7 @@
             <a href="references.html" class="btn btn-secondary">Next: References</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>

--- a/solution.html
+++ b/solution.html
@@ -31,51 +31,7 @@
     </div>
 
     <div id="main-content" class="main-content">
-        <nav class="main-nav">
-            <div class="nav-container">
-                <div class="nav-logo">
-                    <a href="index.html" class="nav-logo-link">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="logo-image">
-                        <span class="logo-text">CareFuse</span>
-                    </a>
-                </div>
-
-                <div class="nav-links">
-                    <a href="index.html" class="nav-link">Home</a>
-                    <a href="problem.html" class="nav-link">Problem</a>
-                    <a href="solution.html" class="nav-link active">Solution</a>
-                    <a href="evidence.html" class="nav-link">Evidence</a>
-                    <a href="application.html" class="nav-link">Application</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Implementation</a>
-                        <div class="dropdown-menu">
-                            <a href="platform.html" class="dropdown-item">Platform</a>
-                            <a href="compliance.html" class="dropdown-item">Compliance</a>
-                            <a href="impact.html" class="dropdown-item">Impact</a>
-                        </div>
-                    </div>
-
-                    <a href="roadmap.html" class="nav-link">Roadmap</a>
-
-                    <div class="nav-dropdown">
-                        <a href="#" class="nav-link dropdown-trigger">Company</a>
-                        <div class="dropdown-menu">
-                            <a href="careers.html" class="dropdown-item">Careers</a>
-                            <a href="contact.html" class="dropdown-item">Contact</a>
-                            <a href="references.html" class="dropdown-item">References</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="nav-actions">
-                    <button class="btn btn-primary" onclick="openDemo()">Request Demo</button>
-                    <button class="mobile-menu-toggle" onclick="toggleMobileMenu()">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
-            </div>
-        </nav>
+        <div id="navigation-placeholder"></div>
 
         <section id="solution" class="solution-section">
             <div class="section-container">
@@ -286,43 +242,7 @@
             <a href="evidence.html" class="btn btn-secondary">Next: Evidence</a>
         </div>
 
-        <footer class="footer">
-            <div class="footer-container">
-                <div class="footer-content">
-                    <div class="footer-brand">
-                        <img src="images/carefuse-logo.png" alt="CareFuse" class="footer-logo">
-                        <span class="footer-brand-text">CareFuse</span>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Product</h4>
-                        <ul>
-                            <li><a href="solution.html">Solution</a></li>
-                            <li><a href="evidence.html">Evidence</a></li>
-                            <li><a href="platform.html">Platform</a></li>
-                        </ul>
-                    </div>
-
-                    <div class="footer-section">
-                        <h4>Company</h4>
-                        <ul>
-                            <li><a href="careers.html">Careers</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="footer-bottom">
-                    <div class="footer-legal">
-                        <p>CareFuse provides decision support to assist licensed clinical reviewers; final coverage determinations are made by the plan's clinicians consistent with plan policies and applicable laws. For California members, AI-generated patient communications include AB-3030 notices or are clinician-reviewed.<sup class="footnote"><a href="references.html#ref14">[14]</a></sup></p>
-                    </div>
-
-                    <div class="footer-bottom-content">
-                        <p>&copy; 2025 CareFuse. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
+        <div id="footer-placeholder"></div>
     </div>
 
     <script src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- inject shared navigation and footer templates via JavaScript so every page shares one implementation
- surface the Solution and Evidence sections on the home page and update global navigation/footer links accordingly
- enlarge button typography, center the footer copyright, and cut the loading delay in half

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e57de36cec83219af4aa6598c2e79a