### PR TITLE
Clarify modeling language and enhance ROI calculator guidance

### DIFF
--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -313,7 +313,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin: 4rem auto 6rem;
+    margin: 4rem auto 2rem;
     max-width: 1400px;
     padding: 0 2rem;
 }
@@ -1455,6 +1455,12 @@ body {
     color: var(--text-primary);
 }
 
+.input-description {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
 .input-group input[type="number"] {
     padding: 0.75rem;
     border: 2px solid var(--border-color);
@@ -1516,6 +1522,13 @@ body {
     border-radius: var(--radius-xl);
     text-align: center;
     box-shadow: var(--shadow-md);
+}
+
+.result-description {
+    margin-top: 0.75rem;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
 }
 
 .result-icon {

--- a/impact.html
+++ b/impact.html
@@ -45,23 +45,27 @@
                     <div class="calculator-inputs">
                         <div class="input-group">
                             <label for="monthly-volume">Monthly TKA/THA PA Volume</label>
+                            <p class="input-description">Average number of hip and knee prior authorization requests your utilization management team processes each month.</p>
                             <input type="number" id="monthly-volume" value="150" min="1">
                         </div>
 
                         <div class="input-group">
                             <label for="approval-rate">Baseline Approval Rate (%)</label>
+                            <p class="input-description">Percentage of requests currently approved for surgery before introducing CareFuse decision support.</p>
                             <input type="range" id="approval-rate" min="60" max="95" value="85">
                             <span class="range-value">85%</span>
                         </div>
 
                         <div class="input-group">
                             <label for="low-benefit">% Predicted Low Benefit</label>
+                            <p class="input-description">Share of approved members that the CareFuse model flags as unlikely to meet MCID based on their clinical profile.</p>
                             <input type="range" id="low-benefit" min="10" max="40" value="25">
                             <span class="range-value">25%</span>
                         </div>
 
                         <div class="input-group">
                             <label for="episode-cost">Average Episode Cost ($)</label>
+                            <p class="input-description">Total payer spend per surgical episode, including facility, professional, and post-acute costs.</p>
                             <input type="number" id="episode-cost" value="25000" min="10000">
                         </div>
                     </div>
@@ -73,6 +77,7 @@
                             </div>
                             <div class="result-value" id="avoided-surgeries">38</div>
                             <div class="result-label">Avoided Surgeries/Year</div>
+                            <p class="result-description">Projected count of TKAs prevented by redirecting low-benefit members to enhanced conservative care pathways.</p>
                         </div>
 
                         <div class="result-card">
@@ -81,6 +86,7 @@
                             </div>
                             <div class="result-value" id="medical-savings">$950,000</div>
                             <div class="result-label">Annual Medical Savings</div>
+                            <p class="result-description">Estimated reduction in direct medical spend by avoiding surgeries and associated acute and post-acute services.</p>
                         </div>
 
                         <div class="result-card">
@@ -89,6 +95,7 @@
                             </div>
                             <div class="result-value" id="admin-savings">$75,000</div>
                             <div class="result-label">Admin Savings</div>
+                            <p class="result-description">Combined peer-to-peer and overturn cost reductions from fewer disputed cases and streamlined reviews.</p>
                         </div>
 
                         <div class="result-card">
@@ -97,6 +104,7 @@
                             </div>
                             <div class="result-value" id="net-roi">$1,025,000</div>
                             <div class="result-label">Net Annual ROI</div>
+                            <p class="result-description">Net financial benefit after accounting for CareFuse licensing and implementation expenses.</p>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
                 <div class="section-header">
                     <div class="section-badge">Clinical Evidence</div>
                     <h2 class="section-title">Validation &amp; Performance</h2>
-                    <p class="section-description">At CareFuse, we've built a calibrated, explainable logistic-regression model (OAI: demographics + WOMAC) that estimates a TKA patient's probability of achieving MCID and generates a counterfactual for conservative care using propensity-score weighting. Across 50 multi-seed holdout splits it achieves AUC ≈ 0.93, with transparent calibration/thresholding and SHAP explanations suited for clinical review.</p>
+                    <p class="section-description">At CareFuse, we've built a calibrated, explainable binary classification model (OAI: demographics + WOMAC) that estimates a TKA patient's probability of achieving MCID and generates a counterfactual for conservative care using propensity-score weighting. Across 50 multi-seed holdout splits it achieves AUC ≈ 0.93, with transparent calibration/thresholding and SHAP explanations suited for clinical review.</p>
                 </div>
 
                 <div class="data-inputs-callout">
@@ -334,7 +334,7 @@
             <div id="methods" class="methods-section">
                 <h3>Methods</h3>
                 <div class="methods-content">
-                    <p>Our model uses logistic regression with demographics and WOMAC scores from the OAI dataset. We completed a live pilot with Hapvida (15.7M policyholders) to demonstrate feasibility and workflow integration. In the U.S., our pilot would train a new model on your de-identified data using the same pipeline and deploy a secure, metered API with audit logging.</p>
+                    <p>Our binary classification model uses demographics and WOMAC scores from the OAI dataset. We completed a live pilot with Hapvida (15.7M policyholders) to demonstrate feasibility and workflow integration. In the U.S., our pilot would train a new model on your de-identified data using the same pipeline and deploy a secure, metered API with audit logging.</p>
                     <p>CareFuse is represented by Gunderson Dettmer, and our product is built under the FDA non-device CDS exemption.</p>
                     <p>We also follow machine learning best practices, including strict train/test data splits, holdout validation, and transparent metric computation to ensure trustworthy, reproducible results.</p>
                 </div>

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -104,7 +104,7 @@ function performROICalculation(data) {
     
     // Reduced overturn costs (legal and administrative)
     const currentOverturns = (annualVolume - currentApprovedCases) * (data.overturnRate / 100);
-    const reducedOverturns = currentOverturns * 0.40; // 40% reduction in overturns
+    const reducedOverturns = currentOverturns * 0.30; // 30% reduction in overturns
     const overturnSavings = reducedOverturns * 2000; // $2000 per overturn case
     
     // Total administrative savings
@@ -355,7 +355,7 @@ function generateReportContent(inputData, results) {
             <ul>
                 <li>75% of identified low-benefit cases can be successfully avoided</li>
                 <li>30% reduction in P2P review cases</li>
-                <li>40% reduction in denial overturn cases</li>
+                <li>30% reduction in denial overturn cases</li>
                 <li>$2,000 average cost per overturn case</li>
                 <li>$300 average cost per P2P review</li>
             </ul>

--- a/problem.html
+++ b/problem.html
@@ -124,7 +124,7 @@
                         <h3>The Evidence Gap Problem</h3>
                         <div class="conservative-stats">
                             <div class="conservative-item">
-                                <span class="stat-number">40%</span>
+                                <span class="stat-number">30%</span>
                                 <span class="stat-label">TKAs Avoidable</span>
                                 <span class="stat-description">With structured conservative care</span>
                             </div>
@@ -139,7 +139,7 @@
                                 <span class="stat-description">Choice due to evidence uncertainty</span>
                             </div>
                         </div>
-                        <p class="card-description">While structured conservative care (education, exercise, weight management) can avoid up to 40% of TKAs, the lack of robust head-to-head comparison evidence makes surgery the default choice. This evidence gap prevents optimal patient-treatment matching.<sup class="footnote"><a href="references.html#ref9">[9]</a></sup></p>
+                        <p class="card-description">While structured conservative care (education, exercise, weight management) can avoid up to 30% of TKAs, the lack of robust head-to-head comparison evidence makes surgery the default choice. This evidence gap prevents optimal patient-treatment matching.<sup class="footnote"><a href="references.html#ref9">[9]</a></sup></p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- replace logistic regression references with binary classification model terminology across the homepage
- tighten the spacing above the shared footer to remove the visible gap on the homepage
- refresh ROI calculator assumptions and descriptions to use 30% avoidance and explain each input and output

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e67580e1648321b59ce95990d3bcd7