### PR TITLE
Refine problem PDF embed and fix footer spacing

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -2110,65 +2110,36 @@ img, svg, video {
     margin-bottom: 2rem;
 }
 
+
 .pdf-layout {
-    display: grid;
-    grid-template-columns: 1fr 320px;
-    gap: 1.5rem;
-    align-items: start;
-    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: flex-start;
+}
+
+.pdf-actions {
+    display: flex;
+    align-items: center;
 }
 
 .pdf-wrapper {
     width: 100%;
     min-width: 0;
+    height: 75vh;
 }
 
 .pdf-wrapper iframe {
     width: 100%;
-    height: 72vh; /* responsive height relative to viewport */
-    border: 1px solid rgba(0,0,0,0.08);
-    border-radius: 8px;
+    height: 100%;
+    border: none;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
     display: block;
 }
 
-.pdf-controls {
-    background: var(--white);
-    border-radius: var(--radius-lg);
-    padding: 1rem;
-    box-shadow: var(--shadow-md);
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: stretch;
-}
-
-.pdf-controls .control-actions {
-    display: flex;
-    gap: 0.75rem;
-}
-
-.pdf-controls .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.pdf-controls .small.muted {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
-
 @media (max-width: 900px) {
-    .pdf-layout {
-        grid-template-columns: 1fr;
-    }
-
-    .pdf-controls {
-        order: 2;
-        width: 100%;
-    }
-
-    .pdf-wrapper iframe {
+    .pdf-wrapper {
         height: 60vh;
     }
 }

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -1979,12 +1979,17 @@ body {
     z-index: 1000;
     opacity: 0;
     pointer-events: none;
+    top: 0;
+    left: 0;
+    transform: translate3d(-9999px, -9999px, 0);
+    will-change: transform, opacity;
     transition: var(--transition-fast);
 }
 
 .tooltip.show {
     opacity: 1;
     pointer-events: auto;
+    transform: translate3d(0, 0, 0);
 }
 
 .tooltip-content h4 {

--- a/problem.html
+++ b/problem.html
@@ -152,22 +152,18 @@
                 <div class="section-header">
                     <span class="section-badge">PROMs Guidance</span>
                     <h2 class="section-title">PRO-PM FAQ — PROMs Guidance (AAOS / CMS)</h2>
-                    <p class="section-description">The PRO-PM Frequently Asked Questions fact sheet outlines PROMs collection, timing, and reporting expectations for hip and knee arthroplasty programs. Providers implementing PROMs collection will find practical details on administration, follow-up timing, and reporting required by CMS.</p>
+                    <p class="section-description">The PRO-PM Frequently Asked Questions fact sheet outlines PROMs collection, timing, and reporting expectations for hip and knee arthroplasty programs.<sup class="footnote"><a href="references.html#ref18">[18]</a></sup> Providers implementing PROMs collection will find practical details on administration, follow-up timing, and reporting required by CMS.</p>
                 </div>
 
                 <div class="pdf-layout">
-                    <div class="pdf-wrapper">
-                        <!-- local PDF file, should be placed alongside this HTML: CMS_prom_requirement.pdf -->
-                        <iframe src="CMS_prom_requirement.pdf" title="PRO-PM FAQ Fact Sheet" frameborder="0" loading="lazy"></iframe>
+                    <div class="pdf-actions">
+                        <a class="btn btn-secondary" href="CMS_prom_requirement.pdf" target="_blank" rel="noopener" aria-label="Open PRO-PM in a new tab"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Open</a>
                     </div>
 
-                    <aside class="pdf-controls" aria-label="PRO-PM document controls">
-                        <div class="control-actions">
-                            <a class="btn btn-secondary" href="CMS_prom_requirement.pdf" target="_blank" rel="noopener" aria-label="Open PRO-PM in a new tab"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Open</a>
-                            <a class="btn btn-primary" href="CMS_prom_requirement.pdf" download aria-label="Download PRO-PM PDF"><i class="fas fa-download" aria-hidden="true"></i> Download</a>
-                        </div>
-                        <p class="small muted">PDF provided for educational purposes. Use the controls to open or download the official PRO‑PM FAQ.</p>
-                    </aside>
+                    <div class="pdf-wrapper">
+                        <!-- local PDF file, should be placed alongside this HTML: CMS_prom_requirement.pdf -->
+                        <iframe src="CMS_prom_requirement.pdf#toolbar=0" title="PRO-PM FAQ Fact Sheet" frameborder="0" loading="lazy"></iframe>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- simplify the PRO-PM FAQ section so the PDF fills the layout with an open button above it and add the required footnote citation
- streamline the PDF embed styling to remove the control sidebar and hide the built-in toolbar for a cleaner reader experience
- reposition hidden tooltips off-screen to eliminate the extra whitespace that appeared beneath the home page footer

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e67fc71828832189768ed9af6cd3c9