### PR TITLE
Enhance ROI modeling and PDF control alignment

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -2110,65 +2110,38 @@ img, svg, video {
     margin-bottom: 2rem;
 }
 
+
 .pdf-layout {
-    display: grid;
-    grid-template-columns: 1fr 320px;
-    gap: 1.5rem;
-    align-items: start;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: stretch;
+}
+
+.pdf-actions {
+    display: flex;
+    align-items: center;
     justify-content: center;
+    width: 100%;
 }
 
 .pdf-wrapper {
     width: 100%;
     min-width: 0;
+    height: 75vh;
 }
 
 .pdf-wrapper iframe {
     width: 100%;
-    height: 72vh; /* responsive height relative to viewport */
-    border: 1px solid rgba(0,0,0,0.08);
-    border-radius: 8px;
+    height: 100%;
+    border: none;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
     display: block;
 }
 
-.pdf-controls {
-    background: var(--white);
-    border-radius: var(--radius-lg);
-    padding: 1rem;
-    box-shadow: var(--shadow-md);
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: stretch;
-}
-
-.pdf-controls .control-actions {
-    display: flex;
-    gap: 0.75rem;
-}
-
-.pdf-controls .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.pdf-controls .small.muted {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
-
 @media (max-width: 900px) {
-    .pdf-layout {
-        grid-template-columns: 1fr;
-    }
-
-    .pdf-controls {
-        order: 2;
-        width: 100%;
-    }
-
-    .pdf-wrapper iframe {
+    .pdf-wrapper {
         height: 60vh;
     }
 }

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -1563,6 +1563,40 @@ body {
     flex-wrap: wrap;
 }
 
+.calculator-assumptions {
+    background: var(--white);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-md);
+    padding: 2rem;
+    line-height: 1.6;
+}
+
+.calculator-assumptions h3 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+}
+
+.calculator-assumptions p {
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+}
+
+.calculator-assumptions ul {
+    margin: 0 0 1rem 1.25rem;
+    padding: 0;
+    color: var(--text-secondary);
+}
+
+.calculator-assumptions li {
+    margin-bottom: 0.75rem;
+}
+
+.calculator-assumptions strong {
+    color: var(--text-primary);
+}
+
 /* CTA Section */
 .cta-section {
     padding: 80px 0;
@@ -1979,12 +2013,17 @@ body {
     z-index: 1000;
     opacity: 0;
     pointer-events: none;
+    top: 0;
+    left: 0;
+    transform: translate3d(-9999px, -9999px, 0);
+    will-change: transform, opacity;
     transition: var(--transition-fast);
 }
 
 .tooltip.show {
     opacity: 1;
     pointer-events: auto;
+    transform: translate3d(0, 0, 0);
 }
 
 .tooltip-content h4 {

--- a/impact.html
+++ b/impact.html
@@ -38,7 +38,7 @@
                 <div class="section-header">
                     <span class="section-badge">Impact &amp; ROI</span>
                     <h2 class="section-title">Financial Impact Calculator</h2>
-                    <p class="section-description">Estimate the financial impact of CareFuse on your utilization management operations.</p>
+                    <p class="section-description">Model the payer savings unlocked when CareFuse prevents low-benefit hip and knee surgeries by redirecting members before authorization.</p>
                 </div>
 
                 <div class="roi-calculator">
@@ -52,15 +52,15 @@
                         <div class="input-group">
                             <label for="approval-rate">Baseline Approval Rate (%)</label>
                             <p class="input-description">Percentage of requests currently approved for surgery before introducing CareFuse decision support.</p>
-                            <input type="range" id="approval-rate" min="60" max="95" value="85">
+                            <input type="range" id="approval-rate" min="60" max="100" value="85">
                             <span class="range-value">85%</span>
                         </div>
 
                         <div class="input-group">
                             <label for="low-benefit">% Predicted Low Benefit</label>
-                            <p class="input-description">Share of approved members that the CareFuse model flags as unlikely to meet MCID based on their clinical profile.</p>
-                            <input type="range" id="low-benefit" min="10" max="40" value="25">
-                            <span class="range-value">25%</span>
+                            <p class="input-description">Share of approved members that the CareFuse model flags as unlikely to meet MCID based on their clinical profile. Locked at 30% using CareFuse's validation benchmarks.</p>
+                            <input type="range" id="low-benefit" min="30" max="30" value="30" disabled>
+                            <span class="range-value">30%</span>
                         </div>
 
                         <div class="input-group">
@@ -75,7 +75,7 @@
                             <div class="result-icon">
                                 <i class="fas fa-calculator"></i>
                             </div>
-                            <div class="result-value" id="avoided-surgeries">38</div>
+                            <div class="result-value" id="avoided-surgeries">344</div>
                             <div class="result-label">Avoided Surgeries/Year</div>
                             <p class="result-description">Projected count of TKAs prevented by redirecting low-benefit members to enhanced conservative care pathways.</p>
                         </div>
@@ -84,7 +84,7 @@
                             <div class="result-icon">
                                 <i class="fas fa-dollar-sign"></i>
                             </div>
-                            <div class="result-value" id="medical-savings">$950,000</div>
+                            <div class="result-value" id="medical-savings">$9.6M</div>
                             <div class="result-label">Annual Medical Savings</div>
                             <p class="result-description">Estimated reduction in direct medical spend by avoiding surgeries and associated acute and post-acute services.</p>
                         </div>
@@ -93,7 +93,7 @@
                             <div class="result-icon">
                                 <i class="fas fa-clock"></i>
                             </div>
-                            <div class="result-value" id="admin-savings">$75,000</div>
+                            <div class="result-value" id="admin-savings">$57k</div>
                             <div class="result-label">Admin Savings</div>
                             <p class="result-description">Combined peer-to-peer and overturn cost reductions from fewer disputed cases and streamlined reviews.</p>
                         </div>
@@ -102,11 +102,22 @@
                             <div class="result-icon">
                                 <i class="fas fa-chart-line"></i>
                             </div>
-                            <div class="result-value" id="net-roi">$1,025,000</div>
+                            <div class="result-value" id="net-roi">$9.5M</div>
                             <div class="result-label">Net Annual ROI</div>
                             <p class="result-description">Net financial benefit after accounting for CareFuse licensing and implementation expenses.</p>
                         </div>
                     </div>
+                </div>
+
+                <div class="calculator-assumptions">
+                    <h3>Model assumptions</h3>
+                    <p>CareFuse surfaces members who are unlikely to achieve clinically meaningful improvement so payers can redirect them to conservative care instead of authorizing a low-benefit procedure.</p>
+                    <ul>
+                        <li><strong>Complication risk:</strong> 7.8% of arthroplasty episodes experience serious inpatient complications that add $14,800 in incremental spend per event.<sup class="footnote"><a href="references.html#ref24">[24]</a></sup></li>
+                        <li><strong>Readmission burden:</strong> 4.2% of cases trigger a 30-day readmission with an average $13,400 medical cost.<sup class="footnote"><a href="references.html#ref25">[25]</a></sup></li>
+                        <li><strong>Revision exposure:</strong> 2.2% of index surgeries require an unplanned revision within the first year at an average cost of $49,360.<sup class="footnote"><a href="references.html#ref26">[26]</a></sup></li>
+                    </ul>
+                    <p>The calculator applies your baseline episode cost plus the expected value of these downstream events to every avoided surgery, assumes 75% of low-benefit approvals can be redirected, and keeps the flagged member rate fixed at 30% based on CareFuse model benchmarks.</p>
                 </div>
 
             </div>

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -1,10 +1,20 @@
 // CareFuse ROI Calculator
 
+// Clinical risk assumptions for avoided surgeries
+const riskAssumptions = {
+    complicationRate: 0.078, // 7.8%
+    complicationCost: 14800,
+    readmissionRate: 0.042, // 4.2%
+    readmissionCost: 13400,
+    revisionRate: 0.022, // 2.2%
+    revisionCost: 49360
+};
+
 // Calculator state
 let calculatorData = {
     monthlyVolume: 150,
     approvalRate: 85,
-    lowBenefit: 25,
+    lowBenefit: 30,
     episodeCost: 25000,
     adminCostPerCase: 150,
     p2pCostPerCase: 300,
@@ -82,7 +92,7 @@ function calculateROI() {
 function performROICalculation(data) {
     // Annual volume
     const annualVolume = data.monthlyVolume * 12;
-    
+
     // Current approved cases
     const currentApprovedCases = annualVolume * (data.approvalRate / 100);
     
@@ -92,10 +102,18 @@ function performROICalculation(data) {
     // Avoided surgeries (assuming 75% of low benefit cases can be avoided)
     const avoidanceRate = 0.75;
     const avoidedSurgeries = Math.round(lowBenefitCases * avoidanceRate);
-    
+
+    // Expected complication/readmission/revision load avoided per surgery
+    const expectedComplicationCost = riskAssumptions.complicationRate * riskAssumptions.complicationCost;
+    const expectedReadmissionCost = riskAssumptions.readmissionRate * riskAssumptions.readmissionCost;
+    const expectedRevisionCost = riskAssumptions.revisionRate * riskAssumptions.revisionCost;
+    const expectedRiskCostPerCase = expectedComplicationCost + expectedReadmissionCost + expectedRevisionCost;
+
+    // Risk-adjusted medical savings
+    const riskAdjustedEpisodeCost = data.episodeCost + expectedRiskCostPerCase;
     // Medical cost savings
-    const medicalSavings = avoidedSurgeries * data.episodeCost;
-    
+    const medicalSavings = avoidedSurgeries * riskAdjustedEpisodeCost;
+
     // Administrative savings
     // Reduced P2P reviews (assume 30% reduction in P2P cases)
     const currentP2PCases = annualVolume * 0.20; // 20% of cases go to P2P
@@ -142,6 +160,11 @@ function performROICalculation(data) {
             currentApprovedCases,
             lowBenefitCases,
             avoidanceRate,
+            expectedComplicationCost,
+            expectedReadmissionCost,
+            expectedRevisionCost,
+            expectedRiskCostPerCase,
+            riskAdjustedEpisodeCost,
             p2pSavings,
             overturnSavings,
             implementationCost,
@@ -174,7 +197,11 @@ function updateResultCard(elementId, value) {
     if (element) {
         // Set the text immediately so any intersection observers/animations
         // see the correctly formatted value (e.g., "$7.3M") on first render.
-        element.textContent = value;
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            element.textContent = value.toLocaleString();
+        } else {
+            element.textContent = value;
+        }
 
         // Trigger animation classes for visual feedback (no text change)
         animateValueChange(element, value);
@@ -252,6 +279,8 @@ function generateROICSV(inputData, results) {
         ['Baseline Approval Rate', inputData.approvalRate + '%'],
         ['Predicted Low Benefit %', inputData.lowBenefit + '%'],
         ['Average Episode Cost', '$' + inputData.episodeCost.toLocaleString()],
+        ['Risk-Adjusted Episode Cost', '$' + Math.round(results.breakdown.riskAdjustedEpisodeCost).toLocaleString()],
+        ['Expected Complication/Readmission/Revision Load per Case', '$' + Math.round(results.breakdown.expectedRiskCostPerCase).toLocaleString()],
         ['', ''],
         ['CALCULATED RESULTS', ''],
         ['Annual Volume', results.breakdown.annualVolume],
@@ -266,6 +295,9 @@ function generateROICSV(inputData, results) {
         ['Payback Period', formatMonths(results.paybackPeriod)],
         ['', ''],
         ['DETAILED BREAKDOWN', ''],
+        ['Expected Complication Cost per Case', '$' + Math.round(results.breakdown.expectedComplicationCost).toLocaleString()],
+        ['Expected Readmission Cost per Case', '$' + Math.round(results.breakdown.expectedReadmissionCost).toLocaleString()],
+        ['Expected Revision Cost per Case', '$' + Math.round(results.breakdown.expectedRevisionCost).toLocaleString()],
         ['P2P Review Savings', '$' + results.breakdown.p2pSavings.toLocaleString()],
         ['Overturn Cost Savings', '$' + results.breakdown.overturnSavings.toLocaleString()],
         ['Avoidance Rate Applied', (results.breakdown.avoidanceRate * 100) + '%']
@@ -358,6 +390,8 @@ function generateReportContent(inputData, results) {
                 <li>30% reduction in denial overturn cases</li>
                 <li>$2,000 average cost per overturn case</li>
                 <li>$300 average cost per P2P review</li>
+                <li>Risk-adjusted savings include expected complication (7.8%), readmission (4.2%), and revision (2.2%) costs</li>
+                <li>CareFuse model flags 30% of approved cases as low-benefit for conservative care navigation</li>
             </ul>
         </section>
         

--- a/problem.html
+++ b/problem.html
@@ -152,22 +152,18 @@
                 <div class="section-header">
                     <span class="section-badge">PROMs Guidance</span>
                     <h2 class="section-title">PRO-PM FAQ — PROMs Guidance (AAOS / CMS)</h2>
-                    <p class="section-description">The PRO-PM Frequently Asked Questions fact sheet outlines PROMs collection, timing, and reporting expectations for hip and knee arthroplasty programs. Providers implementing PROMs collection will find practical details on administration, follow-up timing, and reporting required by CMS.</p>
+                    <p class="section-description">The PRO-PM Frequently Asked Questions fact sheet outlines PROMs collection, timing, and reporting expectations for hip and knee arthroplasty programs.<sup class="footnote"><a href="references.html#ref18">[18]</a></sup> Providers implementing PROMs collection will find practical details on administration, follow-up timing, and reporting required by CMS.</p>
                 </div>
 
                 <div class="pdf-layout">
-                    <div class="pdf-wrapper">
-                        <!-- local PDF file, should be placed alongside this HTML: CMS_prom_requirement.pdf -->
-                        <iframe src="CMS_prom_requirement.pdf" title="PRO-PM FAQ Fact Sheet" frameborder="0" loading="lazy"></iframe>
+                    <div class="pdf-actions">
+                        <a class="btn btn-secondary" href="CMS_prom_requirement.pdf" target="_blank" rel="noopener" aria-label="Open PRO-PM in a new tab"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Open</a>
                     </div>
 
-                    <aside class="pdf-controls" aria-label="PRO-PM document controls">
-                        <div class="control-actions">
-                            <a class="btn btn-secondary" href="CMS_prom_requirement.pdf" target="_blank" rel="noopener" aria-label="Open PRO-PM in a new tab"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Open</a>
-                            <a class="btn btn-primary" href="CMS_prom_requirement.pdf" download aria-label="Download PRO-PM PDF"><i class="fas fa-download" aria-hidden="true"></i> Download</a>
-                        </div>
-                        <p class="small muted">PDF provided for educational purposes. Use the controls to open or download the official PRO‑PM FAQ.</p>
-                    </aside>
+                    <div class="pdf-wrapper">
+                        <!-- local PDF file, should be placed alongside this HTML: CMS_prom_requirement.pdf -->
+                        <iframe src="CMS_prom_requirement.pdf#toolbar=0" title="PRO-PM FAQ Fact Sheet" frameborder="0" loading="lazy"></iframe>
+                    </div>
                 </div>
             </div>
         </section>

--- a/references.html
+++ b/references.html
@@ -229,6 +229,30 @@
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18833530/" class="ref-link" target="_blank" rel="noopener">Medical Decision Making (2008)</a>
                         </div>
                     </div>
+
+                    <div class="reference-item" id="ref24">
+                        <div class="ref-number">24</div>
+                        <div class="ref-content">
+                            <p>Healthcare Cost and Utilization Project. Statistical Brief #210: Characteristics of Inpatient Stays Involving Total Knee Arthroplasty, 2015.</p>
+                            <a href="https://hcup-us.ahrq.gov/reports/statbriefs/sb210-Hospital-Stays-Total-Knee-Arthroplasty-2015.jsp" class="ref-link" target="_blank" rel="noopener">HCUP Statistical Brief #210</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref25">
+                        <div class="ref-number">25</div>
+                        <div class="ref-content">
+                            <p>Healthcare Cost and Utilization Project. Statistical Brief #211: 30-Day Readmissions Following Hospitalization for Total Knee Replacement, 2009–2014.</p>
+                            <a href="https://hcup-us.ahrq.gov/reports/statbriefs/sb211-30-Day-Readmissions-Total-Knee-Replacement.jsp" class="ref-link" target="_blank" rel="noopener">HCUP Statistical Brief #211</a>
+                        </div>
+                    </div>
+
+                    <div class="reference-item" id="ref26">
+                        <div class="ref-number">26</div>
+                        <div class="ref-content">
+                            <p>Agency for Healthcare Research and Quality. Economic burden of revision total knee arthroplasty in the United States.</p>
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34764055/" class="ref-link" target="_blank" rel="noopener">AHRQ Revision TKA Cost Analysis</a>
+                        </div>
+                    </div>
                 </div>
 
             </div>


### PR DESCRIPTION
## Summary
- center the PRO-PM PDF open control above the embedded document for a cleaner presentation
- expand the impact calculator narrative, lock the low-benefit cohort at 30%, extend approval inputs to 100%, and surface the supporting assumption card
- risk-adjust medical savings to include complication, readmission, and revision exposure while updating exports and references with cited benchmarks

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_e_68e67fc71828832189768ed9af6cd3c9